### PR TITLE
Batch calculations

### DIFF
--- a/src/configs/t-line-calculator.config/t-line-calculator.config.service.ts
+++ b/src/configs/t-line-calculator.config/t-line-calculator.config.service.ts
@@ -7,7 +7,7 @@ export class TLineCalculatorConfigService {
        S = SCORE
        W = WEIGHT
        C = CONST
-       F = FUNCTION
+       F = FUNCTION (an equation)
      */
 
     C_FOLLOW_BOOST = 1.25;
@@ -24,11 +24,11 @@ export class TLineCalculatorConfigService {
     C_IDEAL_POSTS_PER_SEC = 3;
 
     // desmos code y=\frac{1}{x+4}\ +\ 0.75
-    F_SEEN_WEIGHT = (x) => (1 / (x + 4)) + 0.75
+    F_SEEN_WEIGHT = (x) => (1 / (x + 4)) + 0.75;
 
     // * https://www.desmos.com/calculator/mglnoluywe
     // * https://www.desmos.com/3d/alifqxuuke
     //min-point on curve is at idealBatchSize = sqrt(2c)
-    F_BATCH_SIZE_MIN_POINT = (c) => Math.sqrt(2 * c)
-    F_IDEAL_BATCH_COUNT = (n, c) => n / this.F_BATCH_SIZE_MIN_POINT(c)
+    F_BATCH_SIZE_MIN_POINT = (c) => Math.sqrt(2 * c);
+    F_IDEAL_BATCH_COUNT = (n, c) => n / this.F_BATCH_SIZE_MIN_POINT(c);
 }

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -1,9 +1,10 @@
 import {Module} from '@nestjs/common';
 import {TLineModule} from './t-line/t-line.module'
 import { TLineCalculatorModule } from './t-line-calculator/t-line-calculator.module';
+import { BatchCalculatorModule } from './batch-calculator/batch-calculator.module';
 
 @Module({
-    imports: [TLineModule, TLineCalculatorModule],
+    imports: [TLineModule, TLineCalculatorModule, BatchCalculatorModule],
 })
 export class AppModule {
 }

--- a/src/modules/batch-calculator/batch-calculator.module.ts
+++ b/src/modules/batch-calculator/batch-calculator.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { BatchCalculatorService } from './batch-calculator.service';
+import { TlineCacherModule } from '../tline-cacher/tline-cacher.module';
+import { TLineCalculatorModule } from '../t-line-calculator/t-line-calculator.module';
+
+@Module({
+  providers: [BatchCalculatorService],
+  exports: [BatchCalculatorService],
+  imports: [TlineCacherModule, TLineCalculatorModule]
+})
+export class BatchCalculatorModule {}

--- a/src/modules/batch-calculator/batch-calculator.service.spec.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.spec.ts
@@ -1,0 +1,179 @@
+import {Test, TestingModule} from '@nestjs/testing';
+import {describe, expect, it, beforeEach} from "@jest/globals";
+import {BatchCalculatorService} from './batch-calculator.service';
+import {TLineCalculatorService} from "../t-line-calculator/t-line-calculator.service";
+import {TLineCalculatorConfigService} from "../../configs/t-line-calculator.config/t-line-calculator.config.service";
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+import {AssertionError} from 'assert'
+import {RawPost} from "../t-line/utils/types";
+import getRaw from '../../utils/getRawPostObject.spec.util'
+import getSortedPostObj from '../../utils/getSortedPostObject.spec.util'
+
+describe('BatchCalculatorService', () => {
+    let service: BatchCalculatorService;
+    let tLineCalculatorService: TLineCalculatorService;
+    let tlineCacherService: TlineCacherService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BatchCalculatorService,
+                TLineCalculatorService,
+                TLineCalculatorConfigService,
+                {
+                    provide: TlineCacherService,
+                    useValue: {
+                        dispatch: jest.fn(),
+                        mutex: jest.fn(),
+                    }
+                },
+            ],
+        }).compile();
+
+        service = module.get<BatchCalculatorService>(BatchCalculatorService);
+        tLineCalculatorService = module.get<TLineCalculatorService>(TLineCalculatorService);
+        tlineCacherService = module.get<TlineCacherService>(TlineCacherService);
+
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    //ensures the function runs when integrated with its utilities
+    it('should sort the batch from high to low, rejecting irrelevant posts', async () => {
+        const MIN_SCORE = 1;
+        const relevanceSpy = jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore');
+        relevanceSpy.mockReturnValueOnce(MIN_SCORE); //reject 1st post at relevance stage
+        relevanceSpy.mockReturnValue(MIN_SCORE+1);  //other posts move to next stage
+        const weightSpy = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
+        weightSpy.mockReturnValueOnce(10);
+        weightSpy.mockReturnValueOnce(11);
+        weightSpy.mockReturnValueOnce(9);
+        weightSpy.mockReturnValueOnce(29);
+        weightSpy.mockReturnValueOnce(9);
+        weightSpy.mockReturnValueOnce(2);
+        weightSpy.mockReturnValueOnce(MIN_SCORE); //reject this post at calculate weight stage
+        const expectedOrder: string[] = ["MOCK3", "MOCK1", "MOCK0", "MOCK2", "MOCK4", "MOCK5",];
+        const inputData: RawPost[] =
+            [getRaw(-1), getRaw(0), getRaw(1), getRaw(2),
+                getRaw(3), getRaw(4), getRaw(5), getRaw(6)];
+
+        const output = await service.batchCalculate(inputData, MIN_SCORE);
+
+        expect(output.length).toBe(expectedOrder.length);
+        for (let i = 0; i < expectedOrder.length; i++) {
+            expect(output[i].id).toBe(expectedOrder[i])
+        }
+    });
+
+    describe('batchCalculate', () => {
+        //test the function with different parameter states
+        it('should throw if minScore < 0', async () => {
+            const call = async () => {
+                await service.batchCalculate([], -1);
+            };
+            await expect(call()).rejects.toThrow(AssertionError);
+        });
+        it('should not throw if minScore === 0', async () => {
+            const call = async () => {
+                await service.batchCalculate([], 0);
+                return true;
+            };
+            await expect(call()).resolves.toBe(true);
+        });
+        it('should return an empty array if an empty array is provided', async () => {
+            const output = await service.batchCalculate([], 10);
+            expect(output.length).toBe(0)
+        });
+
+        //test that the posts are dropped correctly
+        it('should drop rawScore <= minScore posts', async () => {
+            const MIN_SCORE = 10;
+            const spy = jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore');
+            spy.mockReturnValueOnce(MIN_SCORE - 1);
+            spy.mockReturnValueOnce(MIN_SCORE);
+            spy.mockReturnValueOnce(MIN_SCORE + 1);
+
+            const output = await service.batchCalculate([
+                getRaw(0), getRaw(1), getRaw(2)
+            ], MIN_SCORE);
+
+            expect(output.length).toBe(1);
+            expect(output[0].id).toBe("MOCK2");
+        });
+        it('should drop weightedScore <= minScore posts', async () => {
+            const MIN_SCORE = 10;
+            const spy = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
+            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(MIN_SCORE + 1);
+            spy.mockReturnValueOnce(MIN_SCORE - 1);
+            spy.mockReturnValueOnce(MIN_SCORE);
+            spy.mockReturnValueOnce(MIN_SCORE + 1);
+
+            const output = await service.batchCalculate([
+                getRaw(0), getRaw(1), getRaw(2)
+            ], MIN_SCORE);
+
+            expect(output.length).toBe(1);
+            expect(output[0].id).toBe("MOCK2");
+        });
+
+        //ensures identical weightings are weighted for diversity
+        it('should decrease weight of identical posts by total processed/seen (in same sec)', async () => {
+            const RAW_SCORE = 100;
+            const spy = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
+            spy.mockImplementation(jest.fn());
+            jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(0);
+            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(RAW_SCORE);
+            const inputData: RawPost[] =
+                [getRaw(0, "a"), getRaw(1, "a"), getRaw(2, "a"), getRaw(3, "a")];
+
+            await service.batchCalculate(inputData, 0);
+
+            expect(spy).toHaveBeenNthCalledWith(1, RAW_SCORE, 0);
+            expect(spy).toHaveBeenNthCalledWith(2, RAW_SCORE, 1);
+            expect(spy).toHaveBeenNthCalledWith(3, RAW_SCORE, 2);
+            expect(spy).toHaveBeenNthCalledWith(4, RAW_SCORE, 3);
+        });
+    });
+
+    describe('getCachedSeenCount', () => {
+        it('should return the value stored in "seenData" if it exists', async ()=>{
+            const cacheRef = {"test": 69};
+            const out = await service.getCachedSeenCount("test", cacheRef);
+            expect(out).toBe(69);
+        });
+        it('should return the value from redis if it exists', async ()=>{
+            const cacheRef = {};
+            jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(69);
+            const out = await service.getCachedSeenCount("test", cacheRef);
+            expect(out).toBe(69);
+        });
+        it('should return 0 if value is not in local or redis cache', async ()=>{
+            const cacheRef = {};
+            jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(undefined);
+            const out = await service.getCachedSeenCount("test", cacheRef);
+            expect(out).toBe(0);
+        });
+    });
+
+    describe('sortHighToLow', () => {
+        it('should insert the first post at index 0', ()=>{
+            const sorter = [];
+            service.sortHighToLow(sorter, getSortedPostObj(0, 10));
+            expect(sorter[0].id).toBe('MOCK0');
+        });
+        it('should insert the worst post at the end', ()=>{
+            const sorter =
+                [getSortedPostObj(1, 9), getSortedPostObj(2, 5), getSortedPostObj(3, 1)];
+            service.sortHighToLow(sorter, getSortedPostObj(0, 0));
+            expect(sorter[3].id).toBe('MOCK0');
+        });
+        it('should insert the best post at index 0', ()=>{
+            const sorter =
+                [getSortedPostObj(1, 9), getSortedPostObj(2, 5), getSortedPostObj(3, 1)];
+            service.sortHighToLow(sorter, getSortedPostObj(0, 10));
+            expect(sorter[0].id).toBe('MOCK0');
+        });
+    });
+});

--- a/src/modules/batch-calculator/batch-calculator.service.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.ts
@@ -1,0 +1,93 @@
+import {Injectable} from '@nestjs/common';
+import {strictEqual} from 'assert'
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+import {TLineCalculatorService} from "../t-line-calculator/t-line-calculator.service";
+import {TLineCacheQueriesEnum} from "../../utils/TLineCacheQueriesEnum";
+import {RawPost, SortedPost} from "../t-line/utils/types";
+
+@Injectable()
+export class BatchCalculatorService {
+    constructor(
+        private readonly tlineCacheService: TlineCacherService,
+        private readonly tlineCalculatorService: TLineCalculatorService,
+    ) {
+    }
+
+    /**Calculates and ranks a batch of posts
+     *
+     * O(n^2) for limited size of n
+     * This runs concurrently to rank all the posts
+     *
+     * @param batch
+     * @param minScore
+     */
+    async batchCalculate(batch: RawPost[], minScore: number): Promise<SortedPost[]> {
+        strictEqual(minScore >= 0, true, 'batchCalculate -> minScore must be >= 0');
+        if (batch.length === 0) return [];
+
+        const seenDataLocalCache: { [key: string]: number } = {};
+        const sortedData: SortedPost[] = [];
+
+        //calculate scores for all posts in batch and sort them from best to worst
+        //if a posts score indicates that it will never be used, reject it as there is no point processing it
+        for (let i = 0; i < batch.length; i++) {
+            const P = batch[i];
+            //calculate the raw score for this post
+            const rawScore: number = this.tlineCalculatorService.calculateRelevanceScore(
+                P.secRelationalScore, P.postPersonalScore, P.authorsPersonalScore,
+                P.thrRelationalScore, P.autRelation, P.postState);
+            if (rawScore <= minScore) continue; //reject post
+
+            const sec: string = P.sec;
+            //calculate the weighted score based on how many have been seen from this category
+            //this is to create variation in the feed so the same category doesnt come up many times in a row
+            const seen: number = await this.getCachedSeenCount(sec, seenDataLocalCache);
+            const weightScore: number = this.tlineCalculatorService.calculateTotalSeenWeight(rawScore, seen);
+            if (weightScore <= minScore) continue; //reject post
+
+            //sort the un-rejected post
+            this.sortHighToLow(sortedData,
+                {id: P.id, sec: sec, score: weightScore, seen: P.postState.seen, vote: P.postState.vote});
+            seenDataLocalCache[sec]++;
+        }
+
+        return sortedData;
+    }
+
+    //util: interfaces with the caches to figure out how many posts from 'sec' have been marked as seen
+    // it first checks its local cache in seenDataRef. if it does not exist, it writes
+    async getCachedSeenCount(sec: string, seenDataRef: { [key: string]: number }): Promise<number> {
+        //return locally cached value if it exists
+        if (seenDataRef[sec] !== undefined) return seenDataRef[sec];
+
+        //set the local cache value by moving the redis cached value to local cache (defaults to 0 if not exists)
+        try {
+            const seenCount: unknown = await this.tlineCacheService.dispatch(TLineCacheQueriesEnum.GET_SEEN, {sec});
+            if (seenCount === undefined) seenDataRef[sec] = 0;
+            else seenDataRef[sec] = seenCount as number;
+
+            return seenDataRef[sec];
+        } catch (e) {
+            console.error(e);
+            seenDataRef[sec] = 0;
+            return 0;
+        }
+    }
+
+    //util: sorts an individual post in to the already sorted array
+    // worst case: O(n)
+    sortHighToLow(sortedInput: SortedPost[], postToInsert: SortedPost): void {
+        //start at the end and shift each item over by 1
+        // when it finds where the new item should go, insert it and ignore the rest (as theryre already sorted)
+        for (let i = sortedInput.length - 1; i >= 0; i--) {
+            if (sortedInput[i].score >= postToInsert.score) {
+                sortedInput[i + 1] = postToInsert;
+                return;
+            } else sortedInput[i + 1] = sortedInput[i];
+        }
+        // as the loop never returned, that means every item got shifted over and it never found postToInserts slot
+        // this means the only possible option is that postToInsert had the highest score, so it goes in the
+        // slot left available at index 0
+        sortedInput[0] = postToInsert;
+    }
+}

--- a/src/modules/batch-calculator/batch-calculator.service.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.ts
@@ -15,7 +15,8 @@ export class BatchCalculatorService {
 
     /**Calculates and ranks a batch of posts
      *
-     * O(n^2) for limited size of n
+     * Worst case: O(n^2) for limited size of n
+     * best case: O(n) if data is already sorted, or all posts are rejected
      * This runs concurrently to rank all the posts
      *
      * @param batch
@@ -55,7 +56,8 @@ export class BatchCalculatorService {
     }
 
     //util: interfaces with the caches to figure out how many posts from 'sec' have been marked as seen
-    // it first checks its local cache in seenDataRef. if it does not exist, it writes
+    // it first checks its local cache in seenDataRef.
+    // if it does not exist locally, it queries from redis and writes it into the local cache (default to 0 if not found)
     async getCachedSeenCount(sec: string, seenDataRef: { [key: string]: number }): Promise<number> {
         //return locally cached value if it exists
         if (seenDataRef[sec] !== undefined) return seenDataRef[sec];
@@ -75,7 +77,8 @@ export class BatchCalculatorService {
     }
 
     //util: sorts an individual post in to the already sorted array
-    // worst case: O(n)
+    // worst case: O(n) if postToInsert has largest score
+    // best case: O(1) if postToInsert has lowest score
     sortHighToLow(sortedInput: SortedPost[], postToInsert: SortedPost): void {
         //start at the end and shift each item over by 1
         // when it finds where the new item should go, insert it and ignore the rest (as theryre already sorted)

--- a/src/modules/post-ranker-manager/post-ranker-manager.service.ts
+++ b/src/modules/post-ranker-manager/post-ranker-manager.service.ts
@@ -8,19 +8,23 @@ export class PostRankerManagerService {
     async rankPosts(job: JobListing): Promise<number> {
         //data in: raw post data
 
+        // const startCache = []; // precache for this job|user|mode
+        //job description
 
-        // const cached = []; // precache for this job|user|mode
-        // const sortedBatches = SortedPost[][]
-        // const concurrentJobs = Promise<SortedPost[]>[]
-        //
+        // queryFollowedSectionPosts
+        // job = dispatchConcurrentPosts;
+        // output = await jobRunner
 
-
-        //for top cachesize      //   set seen true
-        //for any dropped from original cachesize //set seen false && sec total -- && clear postid's cache data
+        // c = cachesize
+        //const newMin = output[c] score
+        //for startCache[c->0]
+        //   if get(score) < newMin:
+        //      set seen false && sec total -- && clear attrs
+        //   else break;
 
 
         //TODO: seperate out but this will insert into active tline
-        //CACHE2 get cached users pool.  pop job.serve and push to live pool (O(n) // O(job.serve * 2))
+        // push to users pool.  pop job.serve and push to live pool (O(n) // O(job.serve * 2))
         // these are the posts that get broadcast so that their content can be cached
 
         //return total added

--- a/src/modules/post-ranker/post-ranker.module.ts
+++ b/src/modules/post-ranker/post-ranker.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PostRankerService } from './post-ranker.service';
-import { NeoQueryModule } from '../neo-query/neo-query.module';
-import { TlineCacherModule } from '../tline-cacher/tline-cacher.module';
 import { TLineCalculatorModule } from '../t-line-calculator/t-line-calculator.module';
+import {BatchCalculatorModule} from "../batch-calculator/batch-calculator.module";
 
 @Module({
   providers: [PostRankerService],
   exports: [PostRankerService],
-  imports: [NeoQueryModule, TlineCacherModule, TLineCalculatorModule]
+  imports: [BatchCalculatorModule, TLineCalculatorModule]
 })
 export class PostRankerModule {}

--- a/src/modules/post-ranker/post-ranker.service.spec.ts
+++ b/src/modules/post-ranker/post-ranker.service.spec.ts
@@ -11,7 +11,6 @@ import {BatchCalculatorService} from "../batch-calculator/batch-calculator.servi
 describe('PostRankerService', () => {
     let service: PostRankerService;
     let tLineCalculatorService: TLineCalculatorService;
-    let tlineCacherService: TlineCacherService;
     let batchCalculatorService: BatchCalculatorService;
 
     beforeEach(async () => {
@@ -38,7 +37,6 @@ describe('PostRankerService', () => {
 
         service = module.get<PostRankerService>(PostRankerService);
         tLineCalculatorService = module.get<TLineCalculatorService>(TLineCalculatorService);
-        tlineCacherService = module.get<TlineCacherService>(TlineCacherService);
         batchCalculatorService = module.get<BatchCalculatorService>(BatchCalculatorService);
     });
 

--- a/src/modules/post-ranker/post-ranker.service.spec.ts
+++ b/src/modules/post-ranker/post-ranker.service.spec.ts
@@ -6,10 +6,12 @@ import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
 import {TLineCalculatorService} from "../t-line-calculator/t-line-calculator.service";
 import {TLineCalculatorConfigService} from '../../configs/t-line-calculator.config/t-line-calculator.config.service'
 import {RawPost} from "../t-line/utils/types";
+import {InvalidDataError} from "../../utils/InvalidDataError";
 
 describe('PostRankerService', () => {
     let service: PostRankerService;
     let tLineCalculatorService: TLineCalculatorService;
+    let tlineCacherService: TlineCacherService;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -36,39 +38,12 @@ describe('PostRankerService', () => {
 
         service = module.get<PostRankerService>(PostRankerService);
         tLineCalculatorService = module.get<TLineCalculatorService>(TLineCalculatorService);
+        tlineCacherService = module.get<TlineCacherService>(TlineCacherService);
     });
 
     it('should be defined', () => {
         expect(service).toBeDefined();
     });
-
-    describe('todo', () => {
-        it('should drop negative posts', () => {
-            //init / mock data
-            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore')
-                .mockReturnValue(-1);
-            //call rankPosts
-            // const added = service.rankPosts([post]);
-            //ensure return val is 0
-            // expect(added).toBe(0);
-            //ensure no pooled post by this ID
-            //ensure seen does not contain ID
-        });
-    });
-
-    describe('newBatch', () => {
-        it('should return true every s numbers of an iteration', () => {
-            const SIZE = 7;
-            let cnt = 0;
-            for (let i = 0; i <= 3 * SIZE; i++) {
-                cnt++;
-                if (service.newBatch(i, SIZE)) {
-                    expect(cnt).toBe(SIZE);
-                    cnt = 0;
-                }
-            }
-        })
-    })
 
     describe('dispatchConcurrentPosts', () => {
         it('should dispatch a total of [bc] batches for given in&out sizes', () => {
@@ -76,7 +51,7 @@ describe('PostRankerService', () => {
 
             const inputPosts: RawPost[] = [];
             for (let inCnt = 1; inCnt <= 100; inCnt++) {
-                inputPosts.push(getRaw());
+                inputPosts.push(getRaw(inCnt));
                 for (let outCnt = 1; outCnt <= 100; outCnt++) {
                     const bc = tLineCalculatorService.calculateBatchCount(inCnt, outCnt);
                     const jobBuilder = service.dispatchConcurrentPosts(inputPosts, outCnt, 0)
@@ -91,7 +66,7 @@ describe('PostRankerService', () => {
 
             const inputPosts: RawPost[] = [];
             for (let inCnt = 1; inCnt <= 100; inCnt++) {
-                inputPosts.push(getRaw());
+                inputPosts.push(getRaw(inCnt));
                 for (let outCnt = 1; outCnt <= 100; outCnt++) {
                     totalDispatchedCnt = 0;//reset and run
                     service.dispatchConcurrentPosts(inputPosts, outCnt, 0);
@@ -109,10 +84,10 @@ describe('PostRankerService', () => {
             const actualBatchSize = Math.floor(inCnt / bc);
 
             const inputPosts: RawPost[] = []; //generate mock data and run
-            for (let i = 0; i < inCnt; i++) inputPosts.push(getRaw());
+            for (let i = 0; i < inCnt; i++) inputPosts.push(getRaw(inCnt));
             const data: number[] = ( // data holds values overriden by the mock
                 service.dispatchConcurrentPosts(inputPosts, outCnt, 0
-                ) as unknown[])as number[];
+                ) as unknown[]) as number[];
 
             let flag = true; //evaluate the data
             for (let i = 0; i < data.length; i++) {
@@ -124,12 +99,100 @@ describe('PostRankerService', () => {
             }
         })
     });
+
+    describe('batchCalculate', () => {
+        it('should throw if minScore < 0', async () => {
+            const call = async () => {
+                await service.batchCalculate([], -1);
+            };
+            await expect(call).rejects.toThrow(InvalidDataError);
+        });
+        it('should not throw if minScore === 0', async () => {
+            const call = async () => {
+                await service.batchCalculate([], 0);
+                return true;
+            };
+            await expect(call()).resolves.toBe(true);
+        });
+        it('should return an empty array if an empty array is provided', async () => {
+            const output = await service.batchCalculate([], 10);
+            expect(output.length).toBe(0)
+        });
+        it('should drop score <= minScore posts', async () => {
+            const MIN_SCORE = 10;
+
+            const spy = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
+            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(MIN_SCORE+1);
+            spy.mockReturnValueOnce(MIN_SCORE - 1);
+            spy.mockReturnValueOnce(MIN_SCORE);
+            spy.mockReturnValueOnce(MIN_SCORE + 1);
+
+            const output = await service.batchCalculate([
+                getRaw(0), getRaw(1), getRaw(2)
+            ], MIN_SCORE);
+
+            expect(output.length).toBe(1);
+            expect(output[0].id).toBe("MOCK2");
+        });
+        it('should sort the batch from high to low', async () => {
+            const inputData: RawPost[] =
+                [getRaw(0), getRaw(1), getRaw(2), getRaw(3), getRaw(4), getRaw(5)];
+            const expectedOrder: string[] = ["MOCK3", "MOCK1", "MOCK0", "MOCK2", "MOCK4", "MOCK5",];
+            const spy = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
+            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(1);
+            spy.mockReturnValueOnce(10);
+            spy.mockReturnValueOnce(11);
+            spy.mockReturnValueOnce(9);
+            spy.mockReturnValueOnce(29);
+            spy.mockReturnValueOnce(9);
+            spy.mockReturnValueOnce(1);
+
+            const output = await service.batchCalculate(inputData, 0);
+
+            expect(output.length).toBe(inputData.length);
+            for (let i = 0; i < expectedOrder.length; i++) {
+                expect(output[i].id).toBe(expectedOrder[i])
+            }
+        });
+        it('should decrease weight of identical posts by total processed/seen (in same sec)', async () => {
+            const RAW_SCORE = 100;
+            const inputData: RawPost[] =
+                [getRaw(0, "a"), getRaw(1, "a"), getRaw(2, "a"), getRaw(3, "a")];
+            const calculateTotalSeenWeight = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
+            calculateTotalSeenWeight.mockImplementation(jest.fn());
+            jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(0);
+            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(RAW_SCORE);
+
+            await service.batchCalculate(inputData, 0);
+
+            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(1, RAW_SCORE, 0);
+            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(2, RAW_SCORE, 1);
+            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(3, RAW_SCORE, 2);
+            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(4, RAW_SCORE, 3);
+        });
+    });
+
+    //test utils
+
+    describe('newBatch', () => {
+        it('should return true every s numbers of an iteration', () => {
+            const SIZE = 7;
+            let cnt = 0;
+            for (let i = 0; i <= 3 * SIZE; i++) {
+                cnt++;
+                if (service.newBatch(i, SIZE)) {
+                    expect(cnt).toBe(SIZE);
+                    cnt = 0;
+                }
+            }
+        })
+    })
 });
 
-function getRaw(): RawPost {
+function getRaw(id: number, sec?: string): RawPost {
     return {
-        id: "MOCK000",
-        sec: "tests",
+        id: `MOCK${id}`,
+        sec: sec ?? `tests${id}`,
         authorsPersonalScore: 10,
         postPersonalScore: 10,
         thrRelationalScore: 10,

--- a/src/modules/post-ranker/post-ranker.service.spec.ts
+++ b/src/modules/post-ranker/post-ranker.service.spec.ts
@@ -1,17 +1,18 @@
 import {Test, TestingModule} from '@nestjs/testing';
 import {PostRankerService} from './post-ranker.service';
 import {describe, expect, it, beforeEach} from '@jest/globals';
-import {NeoQueryService} from "../neo-query/neo-query.service";
 import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
 import {TLineCalculatorService} from "../t-line-calculator/t-line-calculator.service";
 import {TLineCalculatorConfigService} from '../../configs/t-line-calculator.config/t-line-calculator.config.service'
 import {RawPost} from "../t-line/utils/types";
-import {InvalidDataError} from "../../utils/InvalidDataError";
+import getRaw from '../../utils/getRawPostObject.spec.util'
+import {BatchCalculatorService} from "../batch-calculator/batch-calculator.service";
 
 describe('PostRankerService', () => {
     let service: PostRankerService;
     let tLineCalculatorService: TLineCalculatorService;
     let tlineCacherService: TlineCacherService;
+    let batchCalculatorService: BatchCalculatorService;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -20,10 +21,9 @@ describe('PostRankerService', () => {
                 TLineCalculatorService,
                 TLineCalculatorConfigService,
                 {
-                    provide: NeoQueryService,
+                    provide: BatchCalculatorService,
                     useValue: {
-                        read: jest.fn(),
-                        write: jest.fn(),
+                        batchCalculate: jest.fn(),
                     }
                 },
                 {
@@ -39,6 +39,7 @@ describe('PostRankerService', () => {
         service = module.get<PostRankerService>(PostRankerService);
         tLineCalculatorService = module.get<TLineCalculatorService>(TLineCalculatorService);
         tlineCacherService = module.get<TlineCacherService>(TlineCacherService);
+        batchCalculatorService = module.get<BatchCalculatorService>(BatchCalculatorService);
     });
 
     it('should be defined', () => {
@@ -47,7 +48,7 @@ describe('PostRankerService', () => {
 
     describe('dispatchConcurrentPosts', () => {
         it('should dispatch a total of [bc] batches for given in&out sizes', () => {
-            jest.spyOn(service, 'batchCalculate').mockImplementation()
+            jest.spyOn(batchCalculatorService, 'batchCalculate').mockImplementation()
 
             const inputPosts: RawPost[] = [];
             for (let inCnt = 1; inCnt <= 100; inCnt++) {
@@ -62,7 +63,7 @@ describe('PostRankerService', () => {
         it('should dispatch all posts for given in&out sizes', () => {
             let totalDispatchedCnt = 0; // sum of all [batches.length]
             const mock = jest.fn((a, b) => totalDispatchedCnt += a.length);
-            jest.spyOn(service, 'batchCalculate').mockImplementation(mock);
+            jest.spyOn(batchCalculatorService, 'batchCalculate').mockImplementation(mock);
 
             const inputPosts: RawPost[] = [];
             for (let inCnt = 1; inCnt <= 100; inCnt++) {
@@ -76,7 +77,7 @@ describe('PostRankerService', () => {
         });
         it('should evenly distribute post count across batches', () => {
             const mock = jest.fn((a, b) => a.length);
-            jest.spyOn(service, 'batchCalculate').mockImplementation(mock);
+            jest.spyOn(batchCalculatorService, 'batchCalculate').mockImplementation(mock);
 
             const outCnt = 47; // init
             const inCnt = 777;
@@ -100,79 +101,7 @@ describe('PostRankerService', () => {
         })
     });
 
-    describe('batchCalculate', () => {
-        it('should throw if minScore < 0', async () => {
-            const call = async () => {
-                await service.batchCalculate([], -1);
-            };
-            await expect(call).rejects.toThrow(InvalidDataError);
-        });
-        it('should not throw if minScore === 0', async () => {
-            const call = async () => {
-                await service.batchCalculate([], 0);
-                return true;
-            };
-            await expect(call()).resolves.toBe(true);
-        });
-        it('should return an empty array if an empty array is provided', async () => {
-            const output = await service.batchCalculate([], 10);
-            expect(output.length).toBe(0)
-        });
-        it('should drop score <= minScore posts', async () => {
-            const MIN_SCORE = 10;
-
-            const spy = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
-            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(MIN_SCORE+1);
-            spy.mockReturnValueOnce(MIN_SCORE - 1);
-            spy.mockReturnValueOnce(MIN_SCORE);
-            spy.mockReturnValueOnce(MIN_SCORE + 1);
-
-            const output = await service.batchCalculate([
-                getRaw(0), getRaw(1), getRaw(2)
-            ], MIN_SCORE);
-
-            expect(output.length).toBe(1);
-            expect(output[0].id).toBe("MOCK2");
-        });
-        it('should sort the batch from high to low', async () => {
-            const inputData: RawPost[] =
-                [getRaw(0), getRaw(1), getRaw(2), getRaw(3), getRaw(4), getRaw(5)];
-            const expectedOrder: string[] = ["MOCK3", "MOCK1", "MOCK0", "MOCK2", "MOCK4", "MOCK5",];
-            const spy = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
-            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(1);
-            spy.mockReturnValueOnce(10);
-            spy.mockReturnValueOnce(11);
-            spy.mockReturnValueOnce(9);
-            spy.mockReturnValueOnce(29);
-            spy.mockReturnValueOnce(9);
-            spy.mockReturnValueOnce(1);
-
-            const output = await service.batchCalculate(inputData, 0);
-
-            expect(output.length).toBe(inputData.length);
-            for (let i = 0; i < expectedOrder.length; i++) {
-                expect(output[i].id).toBe(expectedOrder[i])
-            }
-        });
-        it('should decrease weight of identical posts by total processed/seen (in same sec)', async () => {
-            const RAW_SCORE = 100;
-            const inputData: RawPost[] =
-                [getRaw(0, "a"), getRaw(1, "a"), getRaw(2, "a"), getRaw(3, "a")];
-            const calculateTotalSeenWeight = jest.spyOn(tLineCalculatorService, 'calculateTotalSeenWeight');
-            calculateTotalSeenWeight.mockImplementation(jest.fn());
-            jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(0);
-            jest.spyOn(tLineCalculatorService, 'calculateRelevanceScore').mockReturnValue(RAW_SCORE);
-
-            await service.batchCalculate(inputData, 0);
-
-            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(1, RAW_SCORE, 0);
-            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(2, RAW_SCORE, 1);
-            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(3, RAW_SCORE, 2);
-            expect(calculateTotalSeenWeight).toHaveBeenNthCalledWith(4, RAW_SCORE, 3);
-        });
-    });
-
-    //test utils
+    //test util functions
 
     describe('newBatch', () => {
         it('should return true every s numbers of an iteration', () => {
@@ -187,17 +116,5 @@ describe('PostRankerService', () => {
             }
         })
     })
-});
 
-function getRaw(id: number, sec?: string): RawPost {
-    return {
-        id: `MOCK${id}`,
-        sec: sec ?? `tests${id}`,
-        authorsPersonalScore: 10,
-        postPersonalScore: 10,
-        thrRelationalScore: 10,
-        secRelationalScore: 10,
-        autRelation: {follows: false, muted: true, score: 10},
-        postState: {weight: 10, vote: 0, seen: false},
-    }
-}
+});

--- a/src/modules/post-ranker/post-ranker.service.ts
+++ b/src/modules/post-ranker/post-ranker.service.ts
@@ -2,9 +2,9 @@ import {Injectable} from '@nestjs/common';
 import {NeoQueryService} from '../neo-query/neo-query.service';
 import {TlineCacherService} from '../tline-cacher/tline-cacher.service';
 import {TLineCalculatorService} from '../t-line-calculator/t-line-calculator.service';
-import {RawPost} from "../t-line/utils/types";
-import {JobListing, SortedPost} from "../t-line/utils/types"
+import {JobListing, RawPost, SortedPost} from "../t-line/utils/types";
 import {InvalidDataError} from "../../utils/InvalidDataError";
+import {TLineCacheQueriesEnum} from "../../utils/TLineCacheQueriesEnum";
 
 type ConcurrentBatch = Promise<SortedPost[]>
 
@@ -35,16 +35,16 @@ export class PostRankerService {
         const actualBatchSize = Math.floor(inSize / bc);
         const notLeftovers = bc * actualBatchSize;
 
-        //handles unevenly filled batches
-        let leftover = inSize - notLeftovers;
+        let leftoverCounter = inSize - notLeftovers; //handles unevenly filled batches
         let jobBatch: RawPost[] = [];
+
         for (let i = 0; i < notLeftovers; i++) {
             jobBatch.push(rawPool[i]);//dispatch post
 
             if (this.newBatch(i, actualBatchSize)) {
-                if (leftover > 0){ //dispatch overflow post
-                    jobBatch.push(rawPool[inSize - leftover]);
-                    leftover --;
+                if (leftoverCounter > 0) { //dispatch overflow post
+                    jobBatch.push(rawPool[inSize - leftoverCounter]);
+                    leftoverCounter--;
                 }
                 //dispatch this batch and start next one
                 jobBuilder.push(this.batchCalculate(jobBatch, minScore));
@@ -56,18 +56,75 @@ export class PostRankerService {
 
     //O(n^2); run concurrently in batches add warning about time complexity graph
     async batchCalculate(batch: RawPost[], minScore: number): Promise<SortedPost[]> {
+        if (minScore < 0) throw new InvalidDataError('batchCalculate > minScore', 'must be >= 0')
+        if (batch.length === 0) return [];
+
+        const seenData: { [key: string]: number } = {};
         let sortedData: SortedPost[] = [];
-        let sortingData: SortedPost[] = [];
-        //for each post in batch
-        //  call calculateRelevanceScore;
-        //  drop -ve or 0score posts
-        //  drop posts less than minScore
-        //  for sortedData
-        //    pop and push to sorting, adding current post
-        //  sortedData = sortingData
-        //  sortingData = []
+
+        for (let bI = 0; bI < batch.length; bI++) {
+            const P = batch[bI]; // calculate raw score
+            const rawScore = this.tlineCalculatorService.calculateRelevanceScore(
+                P.secRelationalScore, P.postPersonalScore, P.authorsPersonalScore,
+                P.thrRelationalScore, P.autRelation, P.postState);
+            if (rawScore <= minScore) continue; //reject post
+
+            const sec = P.sec; // calculate weighted score
+            const seen: number = await this.getCachedSeenCount(sec, seenData);
+            const weightScore = this.tlineCalculatorService.calculateTotalSeenWeight(rawScore, seen);
+            if (weightScore <= minScore) continue; //reject post
+
+            //sort the post
+            const postBeingSorted = {score: weightScore, id: P.id, postState: P.postState, sec: P.sec};
+            sortedData = this.sort(sortedData, postBeingSorted);
+            seenData[sec]++;
+        }
+
         return sortedData;
     }
+
+    //util to interface with the cache
+    async getCachedSeenCount(sec: string, seenData: { [key: string]: number }): Promise<number> {
+        if (seenData[sec] !== undefined) return seenData[sec];
+
+        const seenCount: unknown = await this.tlineCacheService.dispatch(TLineCacheQueriesEnum.GET_SEEN, {sec});
+        if (seenCount === undefined) seenData[sec] = 0;
+        else seenData[sec] = seenCount as number;
+
+        return seenData[sec];
+    }
+
+    //util to sort an individual post in to the sorted array O(n)
+    sort(sortedInput: SortedPost[], postBeingSorted: SortedPost): SortedPost[] {
+        if (sortedInput.length === 0)
+            return [postBeingSorted]; //first element already sorted
+        const sortingWeight = postBeingSorted.score;
+
+        //if new is smallest, push for O(1)
+        if (sortedInput[sortedInput.length - 1].score >= sortingWeight) {
+            sortedInput.push(postBeingSorted);
+            return sortedInput;
+        }
+
+        //sort data
+        const sortingOutput: SortedPost[] = [];
+        const consumedCount = this.consumePosts(sortingWeight, 0, sortedInput, sortingOutput);
+        sortingOutput.push(postBeingSorted);
+        this.consumePosts(0, consumedCount, sortedInput, sortingOutput);
+
+        return sortingOutput;
+    }
+
+    //util moves sorted posts to sorting array until it reaches the breakScore
+    consumePosts = (breakScore: number, consumedCount: number, sortedInput: SortedPost[], sortingOutput: SortedPost[]): number => {
+        while (consumedCount < sortedInput.length) {
+            if (sortedInput[consumedCount].score < breakScore) break;
+            sortingOutput.push(sortedInput[consumedCount]);
+            consumedCount++;
+        }
+        return consumedCount
+    };
+
 
     // n = number of posts found
     // c = specified cache size (constant)
@@ -81,7 +138,7 @@ export class PostRankerService {
     //worst no-action case iterates o(rb) == o(n) -- already all seen (for each batch; discard all b posts)
     //best re-order case iterates o(rc) == o(fn) -> o(n) -- none discarded, each batch (r) iterates over top [c] elements
     //worst re-order case iterates o(rb+rc)) == o(n + fn) == o((f+1)n) -> o(n) -- one in each batch kept; all others discarded. each batch iterates over b (posts) + c
-    async jobRunner(job: JobListing, batchRunners: ConcurrentBatch[]) {
+    async jobRunner(job: JobListing, batchRunners: ConcurrentBatch[]): Promise<SortedPost[]> {
         // for each concurrent job
         //   sortedB = await concurrentJobs[i]
         //   sortedC = currentCache of length <= job.cache
@@ -94,7 +151,7 @@ export class PostRankerService {
         //     if b < length of sortedB
         //       sB_elm = sortedB[b]
         //       if (seen sB_elm) b++; discard++; continue;
-        //       wB = calculateTotalSeenWeight
+        //       wB = sB_elm weight
         //     else wB = -2
         //
         //     if first valid post is worse than worst in C then its already ordered
@@ -104,16 +161,17 @@ export class PostRankerService {
         //       wC = getWeight(sC_id);
         //       if (wC > wB) c++; sortingBC.push(sC_id); continue?
         //       b++; sortingBC.push(sB_elm.id)
+        //       set:  seen && attrs && sec total ++
         //       CACHE1 update section totalPosts data in :sec:[secid] ++
         //       CACHE1 update seen wB, sec, state etc
         //       break
-
+        return [];
     }
 
     //utility functions
 
     //return true every s iterations to break up data
-    newBatch (i: number, s: number): boolean {
+    newBatch(i: number, s: number): boolean {
         return (i + 1) % s === 0;
     }
 }

--- a/src/modules/t-line-calculator/t-line-calculator.service.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.ts
@@ -39,17 +39,17 @@ export class TLineCalculatorService {
      * i - batch size
      *
      * with
-     * b - batch count = n / i
+     * b = batch count = n / i
      *
      * graph of y = b(c+z) {1 <= b <= n} gives total operations at a given b (batch count)
-     *   where z = (i(i + 1)) / 2
+     *   where z = (i(i + 1)) / 2 (big o of the sorting algorithm)
      *   is equation of the total operations per batch of size {1 <= i <= n}
      * has a min point that lies on y = (n/i) (( (i(i+1)) / 2 ) + c)
      *
      * min point lies on i = sqrt(2c)  for all values of c
      *
      * This simplifies to the 3-D graph of min-points for a given c,n input
-     * y = (n/sqrt(2c))(c+((sqrt(2c))((sqrt(2c)) + 1)) / 2)
+     * y = (sqrt(2c)+0.5) * n
      **
      * @param inputSize
      * @param outputSize

--- a/src/modules/t-line-calculator/t-line-calculator.service.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.ts
@@ -30,7 +30,7 @@ export class TLineCalculatorService {
 
     /**calculate how many batches to optimally run the calculations in
      * https://www.desmos.com/calculator/mglnoluywe
-     * https://www.desmos.com/3d/alifqxuuke
+     * https://www.desmos.com/3d/krga16rwe4
      *
      * the time complexity graph for
      * y - total operations

--- a/src/modules/t-line/utils/types.ts
+++ b/src/modules/t-line/utils/types.ts
@@ -1,3 +1,6 @@
+const DiscoveryModes = import('../utils/DiscoveryModes')
+
+
 export type UserRelation = { follows: boolean, muted: boolean, score: number }
 export type PostState = { weight: number, seen: boolean, vote: number }
 
@@ -15,15 +18,18 @@ tline:[userid]:follow:user:[uid] -> hash of score, normalizedScore and totalPost
 
 export type SortedPost = {
     id: string,
-    sec:string,
-    postState: PostState,
+    sec: string,
+    seen: boolean,
+    vote: number,
     score: number,
 }
 
+export type ConcurrentBatch = Promise<SortedPost[]>
+
 export type JobListing = {
-    readonly jobid:string,
-    readonly userid:string,
-    readonly mode: DiscoveryModes,
+    readonly jobid: string,
+    readonly userid: string,
+    readonly mode: keyof typeof DiscoveryModes,
     readonly query: number,//how many posts from neo
     readonly cache: number,//how many am I hoping for
     readonly serve: number,//how many to give to the final Q
@@ -32,8 +38,8 @@ export type JobListing = {
 }
 
 export type RawPost = {
-    id:string,
-    sec:string,
+    id: string,
+    sec: string,
     secRelationalScore: number,
     postPersonalScore: number,
     authorsPersonalScore: number,

--- a/src/modules/tline-cacher/tline-cacher.service.ts
+++ b/src/modules/tline-cacher/tline-cacher.service.ts
@@ -7,7 +7,7 @@ export class TlineCacherService {
     //TODO: interacts with redis
     //TODO mutex, parse, run, errors, return
 
-    async dispatch(mode:Q, params:{[key:string]:string}, data:unknown): Promise<unknown>{
+    async dispatch(mode:Q, params:{[key:string]:string}, data?:unknown): Promise<unknown>{
         return null;
     }
 

--- a/src/utils/getRawPostObject.spec.util.ts
+++ b/src/utils/getRawPostObject.spec.util.ts
@@ -1,0 +1,14 @@
+import {RawPost} from "../modules/t-line/utils/types";
+
+export default (id: number, sec?: string): RawPost => {
+    return {
+        id: `MOCK${id}`,
+        sec: sec ?? `tests${id}`,
+        authorsPersonalScore: 10,
+        postPersonalScore: 10,
+        thrRelationalScore: 10,
+        secRelationalScore: 10,
+        autRelation: {follows: false, muted: true, score: 10},
+        postState: {weight: 10, vote: 0, seen: false},
+    }
+}

--- a/src/utils/getSortedPostObject.spec.util.ts
+++ b/src/utils/getSortedPostObject.spec.util.ts
@@ -1,0 +1,11 @@
+import {SortedPost} from "../modules/t-line/utils/types";
+
+export default (id: number, score: number, sec?: string): SortedPost => {
+    return {
+        id: `MOCK${id}`,
+        sec: sec ?? `tests${id}`,
+        score: score,
+        seen: false,
+        vote: 0,
+    }
+}


### PR DESCRIPTION
Batch Calculator Implementation

calculates the relevance score for posts, weights them for diversity and then orders them from high to low.

this is intended to be completed concurrently across several batches.

it operates with a worst case time complexity of o(n^2) (more specifically n(n+1) / 2) if the input data is in order of low to high and none are rejected
it operates with a best case time complexity of o(n) if the data is already ordered, or if all posts in this batch get rejected