### PR TITLE
[implemented] JobRunner and blank sub-services

### DIFF
--- a/docs/job-types.md
+++ b/docs/job-types.md
@@ -1,3 +1,12 @@
+# Job Results
+#### Abort
+Abort is used to skip over cascading jobs after an error has already been handled. An example of when
+this would be used is if an INIT job tries to initialize data that has already been initialized by another process.
+
+#### Continue
+Continue is the opposite of the abort job. It is returned when a job is not aborted to indicate that any
+cascading jobs may continue being processed
+
 # Job types
 The job types are events that the system listens for. Some may originate from outside the microservice while
 others may be dispatched from within the service

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -2,9 +2,17 @@ import {Module} from '@nestjs/common';
 import {TLineModule} from './t-line/t-line.module'
 import { TLineCalculatorModule } from './t-line-calculator/t-line-calculator.module';
 import { BatchCalculatorModule } from './batch-calculator/batch-calculator.module';
+import { BatchProcessorService } from './batch-processor/batch-processor.service';
+import { BatchProcessorModule } from './batch-processor/batch-processor.module';
+import { QueryPoolService } from './query-pool/query-pool.service';
+import { QueryPoolModule } from './query-pool/query-pool.module';
+import { ClearCacheModule } from './clear-cache/clear-cache.module';
+import { InitCacheModule } from './init-cache/init-cache.module';
+import { LoadNextPostsModule } from './load-next-posts/load-next-posts.module';
 
 @Module({
-    imports: [TLineModule, TLineCalculatorModule, BatchCalculatorModule],
+    imports: [TLineModule, TLineCalculatorModule, BatchCalculatorModule, BatchProcessorModule, QueryPoolModule, ClearCacheModule, InitCacheModule, LoadNextPostsModule],
+    providers: [BatchProcessorService, QueryPoolService],
 })
 export class AppModule {
 }

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -1,18 +1,24 @@
 import {Module} from '@nestjs/common';
 import {TLineModule} from './t-line/t-line.module'
-import { TLineCalculatorModule } from './t-line-calculator/t-line-calculator.module';
-import { BatchCalculatorModule } from './batch-calculator/batch-calculator.module';
-import { BatchProcessorService } from './batch-processor/batch-processor.service';
-import { BatchProcessorModule } from './batch-processor/batch-processor.module';
-import { QueryPoolService } from './query-pool/query-pool.service';
-import { QueryPoolModule } from './query-pool/query-pool.module';
-import { ClearCacheModule } from './clear-cache/clear-cache.module';
-import { InitCacheModule } from './init-cache/init-cache.module';
-import { LoadNextPostsModule } from './load-next-posts/load-next-posts.module';
+import {TLineCalculatorModule} from './t-line-calculator/t-line-calculator.module';
+import {BatchCalculatorModule} from './batch-calculator/batch-calculator.module';
+import {BatchProcessorModule} from './batch-processor/batch-processor.module';
+import {QueryPoolModule} from './query-pool/query-pool.module';
+import {ClearCacheModule} from './clear-cache/clear-cache.module';
+import {InitCacheModule} from './init-cache/init-cache.module';
+import {LoadNextPostsModule} from './load-next-posts/load-next-posts.module';
 
 @Module({
-    imports: [TLineModule, TLineCalculatorModule, BatchCalculatorModule, BatchProcessorModule, QueryPoolModule, ClearCacheModule, InitCacheModule, LoadNextPostsModule],
-    providers: [BatchProcessorService, QueryPoolService],
+    imports: [
+        TLineModule,
+        TLineCalculatorModule,
+        BatchCalculatorModule,
+        BatchProcessorModule,
+        QueryPoolModule,
+        ClearCacheModule,
+        InitCacheModule,
+        LoadNextPostsModule,
+    ],
 })
 export class AppModule {
 }

--- a/src/modules/batch-processor/batch-processor.module.ts
+++ b/src/modules/batch-processor/batch-processor.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import {BatchCalculatorService} from "../batch-calculator/batch-calculator.service";
+import {TlineCacherModule} from "../tline-cacher/tline-cacher.module";
+
+@Module({
+    providers: [BatchCalculatorService],
+    exports: [BatchCalculatorService],
+    imports: [TlineCacherModule],
+})
+export class BatchProcessorModule {}

--- a/src/modules/batch-processor/batch-processor.service.spec.ts
+++ b/src/modules/batch-processor/batch-processor.service.spec.ts
@@ -1,12 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BatchProcessorService } from './batch-processor.service';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
 
 describe('BatchProcessorService', () => {
   let service: BatchProcessorService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BatchProcessorService],
+      providers: [
+          BatchProcessorService,
+        {
+          provide: TlineCacherService,
+          useValue: {
+            dispatch: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<BatchProcessorService>(BatchProcessorService);

--- a/src/modules/batch-processor/batch-processor.service.spec.ts
+++ b/src/modules/batch-processor/batch-processor.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BatchProcessorService } from './batch-processor.service';
+
+describe('BatchProcessorService', () => {
+  let service: BatchProcessorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BatchProcessorService],
+    }).compile();
+
+    service = module.get<BatchProcessorService>(BatchProcessorService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/batch-processor/batch-processor.service.ts
+++ b/src/modules/batch-processor/batch-processor.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import {ConcurrentBatch, SortedPost} from "../../utils/types";
+
+@Injectable()
+export class BatchProcessorService {
+
+
+    // n = number of posts found
+    // c = specified cache size (constant)
+    // i (dealBatchCount) = (Math.floor(Math.sqrt(2 * c))) (constant)
+    // f = c/i (constant fraction that is the co-efficient in fn = rc)
+    // r = number of runners (total batches)
+    // r = n / i
+    // b = n/r (posts per runner job)
+    //r <= n
+    //best no-action case iterates o(r) == o(n/i) -> o(n) -- already sorted (for each batch; nothing of interest)
+    //worst no-action case iterates o(rb) == o(n) -- already all seen (for each batch; discard all b posts)
+    //best re-order case iterates o(rc) == o(fn) -> o(n) -- none discarded, each batch (r) iterates over top [c] elements
+    //worst re-order case iterates o(rb+rc)) == o(n + fn) == o((f+1)n) -> o(n) -- one in each batch kept; all others discarded. each batch iterates over b (posts) + c
+    async processBatches(batchRunners: ConcurrentBatch[]): Promise<SortedPost[]> {
+        // for each concurrent job
+        //   sortedB = await concurrentJobs[i]
+        //   sortedC = currentCache of length <= job.cache
+        //   sortingBC = [];
+        //   bool: cAtCapacity = cached.length === job.cache
+        //   if cAtCapacity: lowest = getWeight(sortedC[last]);
+        //   else lowest = -1;
+        //   discard,b,c = 0;
+        //   while  c+b-discard <= job.cache;
+        //     if b < length of sortedB
+        //       sB_elm = sortedB[b]
+        //       if (seen sB_elm) b++; discard++; continue;
+        //       wB = sB_elm weight
+        //     else wB = -2
+        //
+        //     if first valid post is worse than worst in C then its already ordered
+        //     if (b-discard === 0 && wB < lowest) sortingBC = sortedC; break;
+        //     while c+b-discard <= job.cache
+        //       sC_id = sortedC[c]
+        //       wC = getWeight(sC_id);
+        //       if (wC > wB) c++; sortingBC.push(sC_id); continue?
+        //       b++; sortingBC.push(sB_elm.id)
+        //       set:  seen && attrs && sec total ++
+        //       CACHE1 update section totalPosts data in :sec:[secid] ++
+        //       CACHE1 update seen wB, sec, state etc
+        //       break
+        return [];
+    }
+}

--- a/src/modules/batch-processor/batch-processor.service.ts
+++ b/src/modules/batch-processor/batch-processor.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import {ConcurrentBatch, SortedPost} from "../../utils/types";
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
 
 @Injectable()
 export class BatchProcessorService {
-
+    constructor(
+        private readonly tlineCacherService: TlineCacherService,
+    ) {}
 
     // n = number of posts found
     // c = specified cache size (constant)

--- a/src/modules/clear-cache/clear-cache.module.ts
+++ b/src/modules/clear-cache/clear-cache.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ClearCacheService } from './clear-cache.service';
+import {TlineCacherModule} from "../tline-cacher/tline-cacher.module";
+
+@Module({
+  providers: [ClearCacheService],
+  exports: [ClearCacheService],
+  imports: [TlineCacherModule],
+})
+export class ClearCacheModule {}

--- a/src/modules/clear-cache/clear-cache.service.spec.ts
+++ b/src/modules/clear-cache/clear-cache.service.spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClearCacheService } from './clear-cache.service';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+
+describe('ClearCacheService', () => {
+  let service: ClearCacheService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+          ClearCacheService,
+        {
+          provide: TlineCacherService,
+          useValue: {
+            dispatch: jest.fn(),
+          },
+        },],
+    }).compile();
+
+    service = module.get<ClearCacheService>(ClearCacheService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/clear-cache/clear-cache.service.ts
+++ b/src/modules/clear-cache/clear-cache.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+import {CacheClearJobListing, JobResult} from "../../utils/types";
+import {JobTypes} from "../../utils/JobTypes";
+
+@Injectable()
+export class ClearCacheService {
+    constructor(
+        private readonly tlineCacherService: TlineCacherService,
+    ) {}
+
+    async clearCacheJob(job: CacheClearJobListing): Promise<JobResult> {
+        return JobTypes.CONTINUE
+    }
+}

--- a/src/modules/init-cache/init-cache.module.ts
+++ b/src/modules/init-cache/init-cache.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { InitCacheService } from './init-cache.service';
+import {TlineCacherModule} from "../tline-cacher/tline-cacher.module";
+
+@Module({
+  providers: [InitCacheService],
+  exports: [InitCacheService],
+  imports: [TlineCacherModule],
+})
+export class InitCacheModule {}

--- a/src/modules/init-cache/init-cache.service.spec.ts
+++ b/src/modules/init-cache/init-cache.service.spec.ts
@@ -1,0 +1,28 @@
+import {Test, TestingModule} from '@nestjs/testing';
+import {InitCacheService} from './init-cache.service';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+
+describe('InitCacheService', () => {
+    let service: InitCacheService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                InitCacheService,
+                {
+                    provide: TlineCacherService,
+                    useValue: {
+                        dispatch: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<InitCacheService>(InitCacheService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/src/modules/init-cache/init-cache.service.ts
+++ b/src/modules/init-cache/init-cache.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import {InitJobListing, JobResult} from "../../utils/types";
+import {JobTypes} from "../../utils/JobTypes";
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+
+@Injectable()
+export class InitCacheService {
+    constructor(
+        private readonly tlineCacherService: TlineCacherService,
+    ) {}
+
+    async initJob(job: InitJobListing): Promise<JobResult> {
+        return JobTypes.CONTINUE
+    }
+}

--- a/src/modules/job-runner/job-runner.module.ts
+++ b/src/modules/job-runner/job-runner.module.ts
@@ -1,0 +1,13 @@
+import {Module} from '@nestjs/common';
+import {JobRunnerService} from "./job-runner.service";
+import {ClearCacheModule} from "../clear-cache/clear-cache.module";
+import {InitCacheModule} from "../init-cache/init-cache.module";
+import {LoadNextPostsModule} from "../load-next-posts/load-next-posts.module";
+import {PostRankerManagerModule} from "../post-ranker-manager/post-ranker-manager.module";
+
+@Module({
+    providers: [JobRunnerService],
+    exports: [JobRunnerService],
+    imports: [ClearCacheModule, InitCacheModule, LoadNextPostsModule, PostRankerManagerModule]
+})
+export class JobRunnerModule {}

--- a/src/modules/job-runner/job-runner.service.spec.ts
+++ b/src/modules/job-runner/job-runner.service.spec.ts
@@ -279,6 +279,8 @@ describe('JobRunnerService', () => {
         });
     });
 
+    //test the helper utils
+    
     describe('doQuery', () => {
         it('should return true for job types QUERY, QUERY_LOAD and INIT', () => {
             const QUERY = service.doQuery(JobTypes.QUERY);

--- a/src/modules/job-runner/job-runner.service.spec.ts
+++ b/src/modules/job-runner/job-runner.service.spec.ts
@@ -1,0 +1,333 @@
+import {Test, TestingModule} from '@nestjs/testing';
+import {JobRunnerService} from './job-runner.service';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {JobTypes} from '../../utils/JobTypes';
+import {
+    CacheClearJobListing,
+    InitJobListing,
+    LoadJobListing,
+    QueryJobListing,
+    QueryLoadJobListing
+} from "../../utils/types";
+import {DiscoveryModes} from "../../utils/DiscoveryModes";
+import {InitCacheService} from "../init-cache/init-cache.service";
+import {PostRankerManagerService} from "../post-ranker-manager/post-ranker-manager.service";
+import {LoadNextPostsService} from "../load-next-posts/load-next-posts.service";
+import {ClearCacheService} from "../clear-cache/clear-cache.service";
+
+describe('JobRunnerService', () => {
+    let service: JobRunnerService;
+    let initCacheService: InitCacheService;
+    let postRankerManagerService: PostRankerManagerService;
+    let loadNextPostsService: LoadNextPostsService;
+    let clearCacheService: ClearCacheService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                JobRunnerService,
+                {
+                    provide: InitCacheService,
+                    useValue: {
+                        initJob: jest.fn(),
+                    },
+                },
+                {
+                    provide: PostRankerManagerService,
+                    useValue: {
+                        queryJob: jest.fn(),
+                    },
+                },
+                {
+                    provide: LoadNextPostsService,
+                    useValue: {
+                        loadJob: jest.fn(),
+                    },
+                },
+                {
+                    provide: ClearCacheService,
+                    useValue: {
+                        clearCacheJob: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<JobRunnerService>(JobRunnerService);
+        initCacheService = module.get<InitCacheService>(InitCacheService);
+        postRankerManagerService = module.get<PostRankerManagerService>(PostRankerManagerService);
+        loadNextPostsService = module.get<LoadNextPostsService>(LoadNextPostsService);
+        clearCacheService = module.get<ClearCacheService>(ClearCacheService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    //NOTE TO DEVELOPER::::::::::::::::::::
+    //
+    //  If the JobRunner is updated, you should ensure any
+    //  new cases are checked against the FAIL_IF_CALLED
+    //  util for all the existing test cases written below
+    //
+    //
+    //
+    //
+
+    describe('jobRunner', () => {
+        //no-call checker util
+        const FAIL_IF_CALLED = async (a) => {
+            expect("this function").toBe("never called");
+            return JobTypes.ABORT
+        };
+
+        //util gets the order that this function was called in (greater the number returned, the later
+        //it was called). it is used to ensure one function is called after another.
+        //I could have used jest-extended but i didnt want to install a whole package
+        //just to run this test that I can do without it anyway
+        const getInvocationOrder = (s: { mock: { invocationCallOrder: number[] } }): number => {
+            return s.mock.invocationCallOrder[0];
+        };
+
+        it('should call init, query and load, in that order, for a successful init job', async () => {
+            const initJobMock = jest.spyOn(initCacheService, 'initJob');
+            const queryJobMock = jest.spyOn(postRankerManagerService, 'queryJob');
+            const loadJobMock = jest.spyOn(loadNextPostsService, 'loadJob');
+            const clearCacheJobMock = jest.spyOn(clearCacheService, 'clearCacheJob');
+
+            initJobMock.mockResolvedValue(JobTypes.CONTINUE);
+            queryJobMock.mockResolvedValue(JobTypes.CONTINUE);
+            loadJobMock.mockResolvedValue(JobTypes.CONTINUE);
+            clearCacheJobMock.mockImplementation(FAIL_IF_CALLED);
+
+            //the only data that jobRunner cares about it jobType
+            const job: InitJobListing = {
+                jobType: JobTypes.INIT,
+                jobid: "jid",
+                userid: "uid",
+                query: 1,
+                publish: 1,
+                cache: 1,
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION],
+            };
+
+            await service.jobRunner(job);
+
+            expect(initJobMock).toBeCalled();
+            //check query called after init
+            expect(getInvocationOrder(queryJobMock)).toBeGreaterThan(getInvocationOrder(initJobMock));
+            //check load was called after query
+            expect(getInvocationOrder(loadJobMock)).toBeGreaterThan(getInvocationOrder(queryJobMock));
+        });
+
+        it('should call only init for an aborted init job', async () => {
+            const initJobMock = jest.spyOn(initCacheService, 'initJob');
+            const queryJobMock = jest.spyOn(postRankerManagerService, 'queryJob');
+            const loadJobMock = jest.spyOn(loadNextPostsService, 'loadJob');
+            const clearCacheJobMock = jest.spyOn(clearCacheService, 'clearCacheJob');
+
+            initJobMock.mockResolvedValue(JobTypes.ABORT);
+            queryJobMock.mockImplementation(FAIL_IF_CALLED);
+            loadJobMock.mockImplementation(FAIL_IF_CALLED);
+            clearCacheJobMock.mockImplementation(FAIL_IF_CALLED);
+
+            //the only data that jobRunner cares about it jobType
+            const job: InitJobListing = {
+                jobType: JobTypes.INIT,
+                jobid: "jid",
+                userid: "uid",
+                query: 1,
+                publish: 1,
+                cache: 1,
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION],
+            };
+
+            await service.jobRunner(job);
+
+            expect(initJobMock).toBeCalled();
+        });
+
+        it('should call query and load, in that order, for a query and load job', async () => {
+            const initJobMock = jest.spyOn(initCacheService, 'initJob');
+            const queryJobMock = jest.spyOn(postRankerManagerService, 'queryJob');
+            const loadJobMock = jest.spyOn(loadNextPostsService, 'loadJob');
+            const clearCacheJobMock = jest.spyOn(clearCacheService, 'clearCacheJob');
+
+            initJobMock.mockImplementation(FAIL_IF_CALLED);
+            queryJobMock.mockResolvedValue(JobTypes.CONTINUE);
+            loadJobMock.mockResolvedValue(JobTypes.CONTINUE);
+            clearCacheJobMock.mockImplementation(FAIL_IF_CALLED);
+
+            //the only data that jobRunner cares about it jobType
+            const job: QueryLoadJobListing = {
+                jobType: JobTypes.QUERY_LOAD,
+                jobid: "jid",
+                userid: "uid",
+                query: 1,
+                publish: 1,
+                cache: 1,
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION],
+            };
+
+            await service.jobRunner(job);
+
+            expect(queryJobMock).toBeCalled();
+            //check load was called after query
+            expect(getInvocationOrder(loadJobMock)).toBeGreaterThan(getInvocationOrder(queryJobMock));
+
+        });
+
+        it('should call only query for an aborted query and load job', async () => {
+            const initJobMock = jest.spyOn(initCacheService, 'initJob');
+            const queryJobMock = jest.spyOn(postRankerManagerService, 'queryJob');
+            const loadJobMock = jest.spyOn(loadNextPostsService, 'loadJob');
+            const clearCacheJobMock = jest.spyOn(clearCacheService, 'clearCacheJob');
+
+            initJobMock.mockImplementation(FAIL_IF_CALLED);
+            queryJobMock.mockResolvedValue(JobTypes.ABORT);
+            loadJobMock.mockImplementation(FAIL_IF_CALLED);
+            clearCacheJobMock.mockImplementation(FAIL_IF_CALLED);
+
+            //the only data that jobRunner cares about it jobType
+            const job: QueryLoadJobListing = {
+                jobType: JobTypes.QUERY_LOAD,
+                jobid: "jid",
+                userid: "uid",
+                query: 1,
+                publish: 1,
+                cache: 1,
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION],
+            };
+
+            await service.jobRunner(job);
+
+            expect(queryJobMock).toBeCalled();
+        });
+
+        it('should call only query for a query job', async () => {
+            const initJobMock = jest.spyOn(initCacheService, 'initJob');
+            const queryJobMock = jest.spyOn(postRankerManagerService, 'queryJob');
+            const loadJobMock = jest.spyOn(loadNextPostsService, 'loadJob');
+            const clearCacheJobMock = jest.spyOn(clearCacheService, 'clearCacheJob');
+
+            initJobMock.mockImplementation(FAIL_IF_CALLED);
+            queryJobMock.mockResolvedValue(JobTypes.CONTINUE);
+            loadJobMock.mockImplementation(FAIL_IF_CALLED);
+            clearCacheJobMock.mockImplementation(FAIL_IF_CALLED);
+
+            //the only data that jobRunner cares about it jobType
+            const job: QueryJobListing = {
+                jobType: JobTypes.QUERY,
+                jobid: "jid",
+                userid: "uid",
+                query: 1,
+                cache: 1,
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION],
+            };
+
+            await service.jobRunner(job);
+
+            expect(queryJobMock).toBeCalled();
+        });
+
+        it('should call only load for a load job', async () => {
+            const initJobMock = jest.spyOn(initCacheService, 'initJob');
+            const queryJobMock = jest.spyOn(postRankerManagerService, 'queryJob');
+            const loadJobMock = jest.spyOn(loadNextPostsService, 'loadJob');
+            const clearCacheJobMock = jest.spyOn(clearCacheService, 'clearCacheJob');
+
+            initJobMock.mockImplementation(FAIL_IF_CALLED);
+            queryJobMock.mockImplementation(FAIL_IF_CALLED);
+            loadJobMock.mockResolvedValue(JobTypes.CONTINUE);
+            clearCacheJobMock.mockImplementation(FAIL_IF_CALLED);
+
+            //the only data that jobRunner cares about it jobType
+            const job: LoadJobListing = {
+                jobType: JobTypes.LOAD,
+                jobid: "jid",
+                userid: "uid",
+                publish: 1,
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION],
+            };
+
+            await service.jobRunner(job);
+
+            expect(loadJobMock).toBeCalled();
+        });
+
+        it('should call only clear cache for a clear cache job', async () => {
+            const initJobMock = jest.spyOn(initCacheService, 'initJob');
+            const queryJobMock = jest.spyOn(postRankerManagerService, 'queryJob');
+            const loadJobMock = jest.spyOn(loadNextPostsService, 'loadJob');
+            const clearCacheJobMock = jest.spyOn(clearCacheService, 'clearCacheJob');
+
+            initJobMock.mockImplementation(FAIL_IF_CALLED);
+            queryJobMock.mockImplementation(FAIL_IF_CALLED);
+            loadJobMock.mockImplementation(FAIL_IF_CALLED);
+            clearCacheJobMock.mockResolvedValue(JobTypes.CONTINUE);
+
+            //the only data that jobRunner cares about it jobType
+            const job: CacheClearJobListing = {
+                jobType: JobTypes.CLEAR_CACHE,
+                jobid: "jid",
+                userid: "uid",
+            };
+
+            await service.jobRunner(job);
+
+            expect(clearCacheJobMock).toBeCalled();
+        });
+    });
+
+    describe('doQuery', () => {
+        it('should return true for job types QUERY, QUERY_LOAD and INIT', () => {
+            const QUERY = service.doQuery(JobTypes.QUERY);
+            const QUERY_LOAD = service.doQuery(JobTypes.QUERY_LOAD);
+            const INIT = service.doQuery(JobTypes.INIT);
+
+            expect(QUERY).toBe(true);
+            expect(QUERY_LOAD).toBe(true);
+            expect(INIT).toBe(true);
+        });
+
+        it('should return false for job types that are not QUERY, QUERY_LOAD and INIT', () => {
+            const WRITE = service.doQuery(JobTypes.WRITE);
+            const CONTINUE = service.doQuery(JobTypes.CONTINUE);
+            const ABORT = service.doQuery(JobTypes.ABORT);
+            const CLEAR_CACHE = service.doQuery(JobTypes.CLEAR_CACHE);
+            const LOAD = service.doQuery(JobTypes.LOAD);
+
+            expect(WRITE).toBe(false);
+            expect(CONTINUE).toBe(false);
+            expect(ABORT).toBe(false);
+            expect(CLEAR_CACHE).toBe(false);
+            expect(LOAD).toBe(false);
+        });
+    });
+
+    describe('doLoad', () => {
+        it('should return true for job types QUERY, QUERY_LOAD and INIT', () => {
+            const LOAD = service.doLoad(JobTypes.LOAD);
+            const QUERY_LOAD = service.doLoad(JobTypes.QUERY_LOAD);
+            const INIT = service.doLoad(JobTypes.INIT);
+
+            expect(LOAD).toBe(true);
+            expect(QUERY_LOAD).toBe(true);
+            expect(INIT).toBe(true);
+        });
+
+        it('should return false for job types that are not QUERY, QUERY_LOAD and INIT', () => {
+            const WRITE = service.doLoad(JobTypes.WRITE);
+            const CONTINUE = service.doLoad(JobTypes.CONTINUE);
+            const ABORT = service.doLoad(JobTypes.ABORT);
+            const CLEAR_CACHE = service.doLoad(JobTypes.CLEAR_CACHE);
+            const QUERY = service.doLoad(JobTypes.QUERY);
+
+            expect(WRITE).toBe(false);
+            expect(CONTINUE).toBe(false);
+            expect(ABORT).toBe(false);
+            expect(CLEAR_CACHE).toBe(false);
+            expect(QUERY).toBe(false);
+        });
+    });
+});

--- a/src/modules/job-runner/job-runner.service.ts
+++ b/src/modules/job-runner/job-runner.service.ts
@@ -1,0 +1,81 @@
+import {Injectable} from '@nestjs/common';
+import {
+    JobResult,
+    CacheClearJobListing,
+    InitJobListing,
+    LoadJobListing,
+    QueryJobListing,
+    QueryLoadJobListing,
+} from "../../utils/types";
+import {JobTypes} from '../../utils/JobTypes';
+import {PostRankerManagerService} from "../post-ranker-manager/post-ranker-manager.service";
+import {InitCacheService} from "../init-cache/init-cache.service";
+import {LoadNextPostsService} from "../load-next-posts/load-next-posts.service";
+import {ClearCacheService} from "../clear-cache/clear-cache.service";
+
+//job listings accepted by the JobRunner
+export type AcceptedRunnerJob = CacheClearJobListing | QueryJobListing |
+    LoadJobListing | QueryLoadJobListing | InitJobListing;
+
+@Injectable()
+export class JobRunnerService {
+    constructor(
+        private readonly postRankerManagerService: PostRankerManagerService,
+        private readonly initCacheService: InitCacheService,
+        private readonly loadNextPostsService: LoadNextPostsService,
+        private readonly clearCacheService: ClearCacheService,
+    ) {}
+
+    /**jobRunner
+     *
+     * The job runner is in charge of managing incoming jobs and ensuring they are completed correctly.
+     * Jobs are read from the queue and processed below
+     *
+     * @param job
+     */
+    async jobRunner(job: AcceptedRunnerJob) {
+        //init job initializes the data in the cache before a job may continue.
+        //if the cache is already initialized, this job will be aborted
+        //if another job attempts to process before data is initialized, it should
+        //dispatch an init job and abort itself
+        if(job.jobType === JobTypes.INIT){
+            const result: JobResult = await this.initCacheService.initJob(job as InitJobListing);
+            if(result === JobTypes.ABORT) return;
+        }
+
+        //Query jobs will get a large pool of data from the neo4j database and condense it down into
+        //a small pool of relevant posts ranked from most to least relevant, stored in the redis cache
+        if(this.doQuery(job.jobType)){
+            const result: JobResult = await this.postRankerManagerService.queryJob(job as QueryJobListing);
+            if(result === JobTypes.ABORT) return;
+        }
+
+        //Load jobs will load the top posts from the pools specified and append them to the end
+        //of the users timeline, and broadcast them to the system so the content service can pre-cache them
+        if(this.doLoad(job.jobType)){
+            const result: JobResult = await this.loadNextPostsService.loadJob(job as LoadJobListing);
+            if(result === JobTypes.ABORT) return;
+        }
+
+        //Clear Cache jobs will clean up the cache when it is no longer needed.
+        //If another job is attempted after the clear was called, it must first call an init job
+        if(job.jobType === JobTypes.CLEAR_CACHE){
+            const result: JobResult = await this.clearCacheService.clearCacheJob(job as CacheClearJobListing);
+            if(result === JobTypes.ABORT) return;
+        }
+    }
+
+    //util to group together jobs that query for more data from neo4j
+    doQuery(jobType: JobTypes){
+        return jobType === JobTypes.QUERY
+            || jobType === JobTypes.QUERY_LOAD
+            || jobType === JobTypes.INIT;
+    }
+
+    //util to group together jobs that load more timeline data into the active timeline
+    doLoad(jobType: JobTypes){
+        return jobType === JobTypes.LOAD
+            || jobType === JobTypes.QUERY_LOAD
+            || jobType === JobTypes.INIT;
+    }
+}

--- a/src/modules/load-next-posts/load-next-posts.module.ts
+++ b/src/modules/load-next-posts/load-next-posts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LoadNextPostsService } from './load-next-posts.service';
+import {TlineCacherModule} from "../tline-cacher/tline-cacher.module";
+
+@Module({
+  providers: [LoadNextPostsService],
+  exports: [LoadNextPostsService],
+  imports: [TlineCacherModule],
+})
+export class LoadNextPostsModule {}

--- a/src/modules/load-next-posts/load-next-posts.service.spec.ts
+++ b/src/modules/load-next-posts/load-next-posts.service.spec.ts
@@ -1,0 +1,28 @@
+import {Test, TestingModule} from '@nestjs/testing';
+import {LoadNextPostsService} from './load-next-posts.service';
+import {beforeEach, describe, expect, it} from '@jest/globals';
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+
+describe('LoadNextPostsService', () => {
+    let service: LoadNextPostsService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                LoadNextPostsService,
+                {
+                    provide: TlineCacherService,
+                    useValue: {
+                        dispatch: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<LoadNextPostsService>(LoadNextPostsService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/src/modules/load-next-posts/load-next-posts.service.ts
+++ b/src/modules/load-next-posts/load-next-posts.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+import {JobResult, LoadJobListing} from "../../utils/types";
+import {JobTypes} from "../../utils/JobTypes";
+
+@Injectable()
+export class LoadNextPostsService {
+    constructor(
+        private readonly tlineCacherService: TlineCacherService,
+    ) {}
+
+    async loadJob(job: LoadJobListing): Promise<JobResult> {
+        //move from one cache to the other
+        return JobTypes.CONTINUE
+    }
+}

--- a/src/modules/post-ranker-manager/post-ranker-manager.module.ts
+++ b/src/modules/post-ranker-manager/post-ranker-manager.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { PostRankerManagerService } from './post-ranker-manager.service';
-import {QueryPoolService} from "../query-pool/query-pool.service";
+import {TlineCacherModule} from "../tline-cacher/tline-cacher.module";
+import {DispatcherModule} from "../dispatcher/dispatcher.module";
+import {QueryPoolModule} from "../query-pool/query-pool.module";
+import {BatchProcessorModule} from "../batch-processor/batch-processor.module";
 
 @Module({
   providers: [PostRankerManagerService],
   exports: [PostRankerManagerService],
-  imports: [QueryPoolService],
+  imports: [TlineCacherModule, QueryPoolModule, DispatcherModule, BatchProcessorModule],
 })
 export class PostRankerManagerModule {}

--- a/src/modules/post-ranker-manager/post-ranker-manager.module.ts
+++ b/src/modules/post-ranker-manager/post-ranker-manager.module.ts
@@ -1,12 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PostRankerManagerService } from './post-ranker-manager.service';
-import { NeoQueryModule } from '../neo-query/neo-query.module';
-import { TlineCacherModule } from '../tline-cacher/tline-cacher.module';
-import { TLineCalculatorModule } from '../t-line-calculator/t-line-calculator.module';
+import {QueryPoolService} from "../query-pool/query-pool.service";
 
 @Module({
   providers: [PostRankerManagerService],
   exports: [PostRankerManagerService],
-  imports: [NeoQueryModule, TlineCacherModule, TLineCalculatorModule]
+  imports: [QueryPoolService],
 })
 export class PostRankerManagerModule {}

--- a/src/modules/post-ranker-manager/post-ranker-manager.service.spec.ts
+++ b/src/modules/post-ranker-manager/post-ranker-manager.service.spec.ts
@@ -1,6 +1,7 @@
 import {Test, TestingModule} from '@nestjs/testing';
 import {PostRankerManagerService} from './post-ranker-manager.service';
 import {describe, expect, it, beforeEach} from '@jest/globals';
+import {QueryPoolService} from "../query-pool/query-pool.service";
 
 describe('PostRankerManagerService', () => {
     let service: PostRankerManagerService;
@@ -9,6 +10,12 @@ describe('PostRankerManagerService', () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 PostRankerManagerService,
+                {
+                    provide: QueryPoolService,
+                    useValue: {
+                        queryAllModes: jest.fn(),
+                    },
+                },
             ],
         }).compile();
 

--- a/src/modules/post-ranker-manager/post-ranker-manager.service.spec.ts
+++ b/src/modules/post-ranker-manager/post-ranker-manager.service.spec.ts
@@ -2,6 +2,9 @@ import {Test, TestingModule} from '@nestjs/testing';
 import {PostRankerManagerService} from './post-ranker-manager.service';
 import {describe, expect, it, beforeEach} from '@jest/globals';
 import {QueryPoolService} from "../query-pool/query-pool.service";
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
+import {DispatcherService} from "../dispatcher/dispatcher.service";
+import {BatchProcessorService} from "../batch-processor/batch-processor.service";
 
 describe('PostRankerManagerService', () => {
     let service: PostRankerManagerService;
@@ -14,6 +17,24 @@ describe('PostRankerManagerService', () => {
                     provide: QueryPoolService,
                     useValue: {
                         queryAllModes: jest.fn(),
+                    },
+                },
+                {
+                    provide: TlineCacherService,
+                    useValue: {
+                        dispatch: jest.fn(),
+                    },
+                },
+                {
+                    provide: DispatcherService,
+                    useValue: {
+                        dispatchConcurrentPosts: jest.fn(),
+                    },
+                },
+                {
+                    provide: BatchProcessorService,
+                    useValue: {
+                        processBatches: jest.fn(),
                     },
                 },
             ],

--- a/src/modules/post-ranker-manager/post-ranker-manager.service.ts
+++ b/src/modules/post-ranker-manager/post-ranker-manager.service.ts
@@ -2,12 +2,19 @@ import {Injectable} from '@nestjs/common';
 import {JobResult, QueryJobListing} from "../../utils/types"
 import {JobTypes} from "../../utils/JobTypes";
 import {QueryPoolService} from "../query-pool/query-pool.service";
+import {DispatcherService} from "../dispatcher/dispatcher.service";
+import {BatchProcessorService} from "../batch-processor/batch-processor.service";
+import {TlineCacherService} from "../tline-cacher/tline-cacher.service";
 
 @Injectable()
 export class PostRankerManagerService {
     constructor(
+        private readonly tlineCacherService: TlineCacherService,
         private readonly queryPoolService: QueryPoolService,
-    ) {}
+        private readonly dispatcherService: DispatcherService,
+        private readonly batchProcessorService: BatchProcessorService,
+    ) {
+    }
 
     async queryJob(job: QueryJobListing): Promise<JobResult> {
         //data in: raw post data
@@ -17,7 +24,7 @@ export class PostRankerManagerService {
 
         // queryFollowedSectionPosts
         // job = dispatchConcurrentPosts;
-        // output = await jobRunner
+        // output = await batch-processor
 
         // c = cachesize
         //const newMin = output[c] score

--- a/src/modules/post-ranker-manager/post-ranker-manager.service.ts
+++ b/src/modules/post-ranker-manager/post-ranker-manager.service.ts
@@ -1,11 +1,15 @@
 import {Injectable} from '@nestjs/common';
-import {GenericJobListing} from "../../utils/types"
+import {JobResult, QueryJobListing} from "../../utils/types"
+import {JobTypes} from "../../utils/JobTypes";
+import {QueryPoolService} from "../query-pool/query-pool.service";
 
 @Injectable()
 export class PostRankerManagerService {
-    constructor() {}
+    constructor(
+        private readonly queryPoolService: QueryPoolService,
+    ) {}
 
-    async rankPosts(job: GenericJobListing): Promise<number> {
+    async queryJob(job: QueryJobListing): Promise<JobResult> {
         //data in: raw post data
 
         // const startCache = []; // precache for this job|user|mode
@@ -22,28 +26,11 @@ export class PostRankerManagerService {
         //      set seen false && sec total -- && clear attrs
         //   else break;
 
-
-        //TODO: seperate out but this will insert into active tline
-        // push to users pool.  pop job.serve and push to live pool (O(n) // O(job.serve * 2))
-        // these are the posts that get broadcast so that their content can be cached
-
         //return total added
-        return 0;
+        return JobTypes.CONTINUE
     };
 
-
-
-    async queryFollowedSectionPosts(postSlots: number) {
-        //const secsAvaialab
-        // x = calculateSectionsToQuery(postSlots: number, secsAvailable: number)
-        //pop x sections from cache
-        //query from neo || mock
-
-        //rank posts (concurrent batch count set)
-
-        //for each update and splice section into cache (based on sec normalized score && total seen)
-    }
-
+    //some old notes
     //choose mode
     // x = calculateSectionsToQuery
     // pop top x

--- a/src/modules/query-pool/query-pool.module.ts
+++ b/src/modules/query-pool/query-pool.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import {NeoQueryModule} from "../neo-query/neo-query.module";
+import {QueryPoolService} from "./query-pool.service";
+import {TLineCalculatorModule} from "../t-line-calculator/t-line-calculator.module";
+
+@Module({
+    providers: [QueryPoolService],
+    exports: [QueryPoolService],
+    imports: [NeoQueryModule, TLineCalculatorModule]
+})
+export class QueryPoolModule {}

--- a/src/modules/query-pool/query-pool.service.spec.ts
+++ b/src/modules/query-pool/query-pool.service.spec.ts
@@ -1,0 +1,35 @@
+import {Test, TestingModule} from '@nestjs/testing';
+import {QueryPoolService} from './query-pool.service';
+import {describe, expect, it, beforeEach} from '@jest/globals';
+import {TLineCalculatorService} from "../t-line-calculator/t-line-calculator.service";
+import {NeoQueryService} from "../neo-query/neo-query.service";
+
+describe('QueryPoolService', () => {
+    let service: QueryPoolService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                QueryPoolService,
+                {
+                    provide: NeoQueryService,
+                    useValue: {
+                        read: jest.fn(),
+                    },
+                },
+                {
+                    provide: TLineCalculatorService,
+                    useValue: {
+                        calculateSectionsToQuery: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<QueryPoolService>(QueryPoolService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/src/modules/query-pool/query-pool.service.ts
+++ b/src/modules/query-pool/query-pool.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import {QueryData, QueryJobListing} from "../../utils/types";
+import {NeoQueryService} from "../neo-query/neo-query.service";
+import {TLineCalculatorService} from "../t-line-calculator/t-line-calculator.service";
+
+@Injectable()
+export class QueryPoolService {
+    constructor(
+        private readonly neoQueryService: NeoQueryService,
+        private readonly tlineCalculatorService: TLineCalculatorService,
+    ) {}
+
+    /**queryAllModes
+     *
+     * runs the query modes that the job has requested and returns an object containing the data retrieved
+     *
+     * @param job
+     */
+    async queryAllModes(job: QueryJobListing): Promise<QueryData>{
+        return {};
+    }
+
+    //notes
+    async queryFollowedSectionPosts(postSlots: number) {
+        //const secsAvaialab
+        // x = calculateSectionsToQuery(postSlots: number, secsAvailable: number)
+        //pop x sections from cache
+        //query from neo || mock
+
+        //rank posts (concurrent batch count set)
+
+        //for each update and splice section into cache (based on sec normalized score && total seen)
+    }
+}

--- a/src/utils/JobTypes.ts
+++ b/src/utils/JobTypes.ts
@@ -1,0 +1,10 @@
+export enum JobTypes {
+    INIT,
+    QUERY,
+    LOAD,
+    QUERY_LOAD,
+    CLEAR_CACHE,
+    WRITE,
+    ABORT,
+    CONTINUE,
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,5 @@
-import {DiscoveryModes} from 'DiscoveryModes';
-import {JobTypes} from 'JobTypes';
+import {DiscoveryModes} from 'DiscoveryModes'
+import {JobTypes} from 'JobTypes'
 
 export type UserRelation = { follows: boolean, muted: boolean, score: number }
 export type PostState = { weight: number, seen: boolean, vote: number }
@@ -15,6 +15,8 @@ export type RawPost = {
     postState: PostState
 }
 
+export type QueryData = {[jobMode: string]: RawPost[]};
+
 export type SortedPost = {
     id: string,
     sec: string,
@@ -25,38 +27,43 @@ export type SortedPost = {
 
 export type ConcurrentBatch = Promise<SortedPost[]>
 
+export type CASCADE = JobTypes.QUERY_LOAD | JobTypes.INIT;
+export type JobResult = JobTypes.ABORT | JobTypes.CONTINUE;
+
 //generic job listing
-export type GenericJobListing = {
+export interface GenericJobListing {
+    readonly jobType: unknown,
     readonly jobid: string,
     readonly userid: string,
     readonly broadcast?: unknown,
 }
 
-export type CacheClearJobListing = {
+export interface CacheClearJobListing extends GenericJobListing {
     readonly jobType: JobTypes.CLEAR_CACHE,
-} & GenericJobListing
+}
 
-export type QueryJobListing = {
-    readonly jobType: JobTypes.QUERY,
-    //mode for the query
-    readonly mode: DiscoveryModes,
+export interface QueryJobListing extends GenericJobListing {
+    readonly jobType: JobTypes.QUERY | CASCADE,
+    //modes for the query
+    readonly modes: DiscoveryModes[],
     //how large should the queried input be
     readonly query: number,
     //how large should the cache // output be
     readonly cache: number,
-} & GenericJobListing;
+} 
 
-export type LoadJobListing = {
-    readonly jobType: JobTypes.LOAD,
+export interface LoadJobListing extends GenericJobListing {
+    readonly jobType: JobTypes.LOAD | CASCADE,
+    //what pools of data should be loaded
+    readonly modes: DiscoveryModes[],
     //The total qty of posts to publish to the user
     readonly publish: number,
-} & GenericJobListing;
+}
 
-export type QueryLoadJobListing = {
+export interface QueryLoadJobListing extends LoadJobListing, QueryJobListing {
     readonly jobType: JobTypes.QUERY_LOAD,
-} & LoadJobListing & QueryJobListing;
+} 
 
-export type InitJobListing = {
+export interface InitJobListing extends LoadJobListing, QueryJobListing {
     readonly jobType: JobTypes.INIT,
-} & QueryLoadJobListing;
-
+}


### PR DESCRIPTION
The JobRunner handles incoming jobs and routes them to the correct services to complete the job. 

This PR has set that up, and initialised all of the services that it calls with boilerplate code