### PR TITLE
documentation for the cache and minor stage 2 modifications

### DIFF
--- a/docs/neo.md
+++ b/docs/neo.md
@@ -120,6 +120,8 @@ The existence of this connection represents the post having been viewed.
 _Attributes_
 
 - vote: number -1 <= x <= 1
+- sess: string - session last seen in
+- seen: number - strength of the view, (no viewport, scroll past or long view)
 
 ### RecipeInteraction
 

--- a/src/configs/t-line-calculator.config/t-line-calculator.config.service.ts
+++ b/src/configs/t-line-calculator.config/t-line-calculator.config.service.ts
@@ -13,6 +13,7 @@ export class TLineCalculatorConfigService {
     C_FOLLOW_BOOST = 1.25;
 
     SW_SEC_REL = 2;
+    SW_SEC_PER = 1.25;
     SW_AUTHOR_PER = 1.5;
     SW_AUTHOR_REL = 1.5;
     SW_THREAD_REL = 1;

--- a/src/modules/batch-calculator/batch-calculator.service.spec.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.spec.ts
@@ -187,7 +187,7 @@ describe('BatchCalculatorService', () => {
                 getRaw(3, 'a'),
             ];
 
-            await service.batchCalculate(inputData, 0, "userId");
+            await service.batchCalculate(inputData, 0, 'userId');
 
             expect(spy).toHaveBeenNthCalledWith(1, RAW_SCORE, 0);
             expect(spy).toHaveBeenNthCalledWith(2, RAW_SCORE, 1);
@@ -200,7 +200,7 @@ describe('BatchCalculatorService', () => {
         it('should return the value stored in "seenData" if it exists', async () => {
             //if the value is locally cached, it should return that value
             const cacheRef = { test: 69 };
-            const out = await service.getCachedSeenCount(cacheRef, 'test', "userId");
+            const out = await service.getCachedSeenCount(cacheRef, 'test', 'userId');
             expect(out).toBe(69);
         });
 
@@ -210,7 +210,7 @@ describe('BatchCalculatorService', () => {
             jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(69);
 
             const cacheRef = {};
-            const out = await service.getCachedSeenCount(cacheRef, 'test', "userId");
+            const out = await service.getCachedSeenCount(cacheRef, 'test', 'userId');
 
             expect(out).toBe(69);
             expect(cacheRef['test']).toBe(69);
@@ -222,7 +222,7 @@ describe('BatchCalculatorService', () => {
             jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(undefined);
 
             const cacheRef = {};
-            const out = await service.getCachedSeenCount(cacheRef, 'test', "userId");
+            const out = await service.getCachedSeenCount(cacheRef, 'test', 'userId');
             expect(out).toBe(0);
             expect(cacheRef['test']).toBe(0);
         });
@@ -260,25 +260,23 @@ describe('BatchCalculatorService', () => {
     });
 
     describe('reject posts seen in this session', () => {
-        it('should reject posts that have a seen sess id equal to the current session', () => {
+        it('should reject posts that have a seen sess id equal to the current session', () => {});
 
-        });
+        it('should reject posts that are in the metadata cache as they are already in a pool', () => {});
 
-        it('should reject posts that are in the metadata cache as they are already in a pool', ()=> {
-
-        });
-
-        it('should not reject posts that are of a different sess id and not in the metadata cache', () => {
-
-        });
-    })
+        it('should not reject posts that are of a different sess id and not in the metadata cache', () => {});
+    });
 
     describe('reject muted', () => {
-        it('should reject posts by muted authors', ()=> {
-
-        })
-        it('should reject posts in muted communities', ()=> {
-
-        })
-    })
+        it('should reject posts by muted authors', async () => {
+            const mutedUser = getRaw(0, "sec", true, false);
+            const output = await service.batchCalculate([mutedUser], 0, 'userId');
+            expect(output.length).toBe(0);
+        });
+        it('should reject posts in muted communities', async () => {
+            const mutedCommunity = getRaw(0, "sec", false, true);
+            const output = await service.batchCalculate([mutedCommunity], 0, 'userId');
+            expect(output.length).toBe(0);
+        });
+    });
 });

--- a/src/modules/batch-calculator/batch-calculator.service.spec.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.spec.ts
@@ -80,7 +80,7 @@ describe('BatchCalculatorService', () => {
             getRaw(6),
         ];
 
-        const output = await service.batchCalculate(inputData, REJECT_SCORE);
+        const output = await service.batchCalculate(inputData, REJECT_SCORE, 'userId');
 
         expect(output.length).toBe(expectedOrder.length);
         for (let i = 0; i < expectedOrder.length; i++) {
@@ -92,7 +92,7 @@ describe('BatchCalculatorService', () => {
         it('should throw if minScore < 0', async () => {
             //The reject score should never be negative
             const call = async () => {
-                await service.batchCalculate([], -1);
+                await service.batchCalculate([], -1, 'userId');
             };
             await expect(call()).rejects.toThrow(AssertionError);
         });
@@ -100,7 +100,7 @@ describe('BatchCalculatorService', () => {
         it('should not throw if minScore === 0', async () => {
             //0 is on the boundary, but is valid
             const call = async () => {
-                await service.batchCalculate([], 0);
+                await service.batchCalculate([], 0, 'userId');
                 return true;
             };
             await expect(call()).resolves.toBe(true);
@@ -108,7 +108,7 @@ describe('BatchCalculatorService', () => {
 
         it('should return an empty array if an empty array is provided', async () => {
             //tests that the system doesnt get confused if the batch is empty for some reason
-            const output = await service.batchCalculate([], 10);
+            const output = await service.batchCalculate([], 10, 'userId');
             expect(output.length).toBe(0);
         });
 
@@ -127,6 +127,7 @@ describe('BatchCalculatorService', () => {
             const output = await service.batchCalculate(
                 [getRaw(0), getRaw(1), getRaw(2)],
                 REJECT_SCORE,
+                'userId',
             );
 
             expect(output.length).toBe(1);
@@ -152,6 +153,7 @@ describe('BatchCalculatorService', () => {
             const output = await service.batchCalculate(
                 [getRaw(0), getRaw(1), getRaw(2)],
                 REJECT_SCORE,
+                'userId',
             );
 
             expect(output.length).toBe(1);
@@ -185,7 +187,7 @@ describe('BatchCalculatorService', () => {
                 getRaw(3, 'a'),
             ];
 
-            await service.batchCalculate(inputData, 0);
+            await service.batchCalculate(inputData, 0, "userId");
 
             expect(spy).toHaveBeenNthCalledWith(1, RAW_SCORE, 0);
             expect(spy).toHaveBeenNthCalledWith(2, RAW_SCORE, 1);
@@ -198,7 +200,7 @@ describe('BatchCalculatorService', () => {
         it('should return the value stored in "seenData" if it exists', async () => {
             //if the value is locally cached, it should return that value
             const cacheRef = { test: 69 };
-            const out = await service.getCachedSeenCount(cacheRef, 'test');
+            const out = await service.getCachedSeenCount(cacheRef, 'test', "userId");
             expect(out).toBe(69);
         });
 
@@ -208,7 +210,7 @@ describe('BatchCalculatorService', () => {
             jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(69);
 
             const cacheRef = {};
-            const out = await service.getCachedSeenCount(cacheRef, 'test');
+            const out = await service.getCachedSeenCount(cacheRef, 'test', "userId");
 
             expect(out).toBe(69);
             expect(cacheRef['test']).toBe(69);
@@ -220,7 +222,7 @@ describe('BatchCalculatorService', () => {
             jest.spyOn(tlineCacherService, 'dispatch').mockResolvedValue(undefined);
 
             const cacheRef = {};
-            const out = await service.getCachedSeenCount(cacheRef, 'test');
+            const out = await service.getCachedSeenCount(cacheRef, 'test', "userId");
             expect(out).toBe(0);
             expect(cacheRef['test']).toBe(0);
         });

--- a/src/modules/batch-calculator/batch-calculator.service.spec.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.spec.ts
@@ -250,7 +250,7 @@ describe('BatchCalculatorService', () => {
             expect(sorter[0].id).toBe('MOCK0');
         });
 
-        it('should insert the identical posts at the bottom', () => {
+        it('should insert posts with identical scores at the bottom of the ones containing that score', () => {
             //place identical posts at the bottom, as there is no point
             //iterating over the posts of the same score for no reason
             const sorter = [getSortedPostObj(1, 9)];
@@ -258,4 +258,27 @@ describe('BatchCalculatorService', () => {
             expect(sorter[1].id).toBe('MOCK0');
         });
     });
+
+    describe('reject posts seen in this session', () => {
+        it('should reject posts that have a seen sess id equal to the current session', () => {
+
+        });
+
+        it('should reject posts that are in the metadata cache as they are already in a pool', ()=> {
+
+        });
+
+        it('should not reject posts that are of a different sess id and not in the metadata cache', () => {
+
+        });
+    })
+
+    describe('reject muted', () => {
+        it('should reject posts by muted authors', ()=> {
+
+        })
+        it('should reject posts in muted communities', ()=> {
+
+        })
+    })
 });

--- a/src/modules/batch-calculator/batch-calculator.service.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.ts
@@ -50,25 +50,25 @@ export class BatchCalculatorService {
         //calculate scores for all posts in batch and sort them from best to worst
         //if a posts score indicates that it will never be used, reject it as there is no point processing it
         for (let i = 0; i < batch.length; i++) {
-            const P: RawPost = batch[i];
-
+            const post: RawPost = batch[i];
+            
             //TODO: if P.postState.sess === sessId, reject post
 
             //TODO: if queryCache(metadata, postId) exists, reject post
 
             //calculate the raw score for this post
             const rawScore: number = this.tlineCalculatorService.calculateRelevanceScore(
-                P.secPersonalScore,
-                P.postPersonalScore,
-                P.authorsPersonalScore,
-                P.thrRelationalScore,
-                P.autRelation,
-                P.secRelation,
-                P.postState,
+                post.secPersonalScore,
+                post.postPersonalScore,
+                post.authorsPersonalScore,
+                post.thrRelationalScore,
+                post.autRelation,
+                post.secRelation,
+                post.postState,
             );
             if (rawScore <= rejectScore) continue; //reject post
 
-            const sec = P.sec;
+            const sec = post.sec;
             //calculate the weighted score based on how many have been seen from this category
             //this is to create variation in the feed so the same category doesnt come up many times in a row
             const seen: number = await this.getCachedSeenCount(seenDataLocalCacheRef, sec, userId);
@@ -80,11 +80,11 @@ export class BatchCalculatorService {
 
             //sort the un-rejected post
             this.sortHighToLow(sortedDataRef, {
-                id: P.id,
+                id: post.id,
                 sec: sec,
                 score: weightScore,
-                seen: P.postState.seen,
-                vote: P.postState.vote,
+                seen: post.postState.seen,
+                vote: post.postState.vote,
             });
             seenDataLocalCacheRef[sec]++;
         }

--- a/src/modules/batch-calculator/batch-calculator.service.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.ts
@@ -58,11 +58,12 @@ export class BatchCalculatorService {
 
             //calculate the raw score for this post
             const rawScore: number = this.tlineCalculatorService.calculateRelevanceScore(
-                P.secRelationalScore,
+                P.secPersonalScore,
                 P.postPersonalScore,
                 P.authorsPersonalScore,
                 P.thrRelationalScore,
                 P.autRelation,
+                P.secRelation,
                 P.postState,
             );
             if (rawScore <= rejectScore) continue; //reject post

--- a/src/modules/batch-calculator/batch-calculator.service.ts
+++ b/src/modules/batch-calculator/batch-calculator.service.ts
@@ -51,7 +51,11 @@ export class BatchCalculatorService {
         //if a posts score indicates that it will never be used, reject it as there is no point processing it
         for (let i = 0; i < batch.length; i++) {
             const post: RawPost = batch[i];
-            
+
+            //if the author or community are muted, reject this post
+            if(post.autRelation.muted) continue;
+            if(post.secRelation.muted) continue;
+
             //TODO: if P.postState.sess === sessId, reject post
 
             //TODO: if queryCache(metadata, postId) exists, reject post

--- a/src/modules/dispatcher/dispatcher.service.spec.ts
+++ b/src/modules/dispatcher/dispatcher.service.spec.ts
@@ -68,7 +68,7 @@ describe('DispatcherService', () => {
 
             //out size and minscore are irrelevant, they are passed onto other functions
             //and their values are tested accordingly within those unit tests
-            service.dispatchConcurrentPosts(inputPosts, 100, 0);
+            service.dispatchConcurrentPosts(inputPosts, 100, 0, "userId");
 
             //tests that the correct number of batches were dispatched
             expect(testData.length).toBe(BATCH_COUNT);
@@ -104,7 +104,7 @@ describe('DispatcherService', () => {
 
             //out size and minscore are irrelevant, they are passed onto other functions
             //and their values are tested accordingly within those unit tests
-            service.dispatchConcurrentPosts(inputPosts, 100, 0);
+            service.dispatchConcurrentPosts(inputPosts, 100, 0, "userId");
 
             //tests that the correct number of batches were dispatched
             expect(testData.length).toBe(BATCH_COUNT);
@@ -155,7 +155,7 @@ describe('DispatcherService', () => {
 
             //out size and minscore are irrelevant, they are passed onto other functions
             //and their values are tested accordingly within those unit tests
-            service.dispatchConcurrentPosts(inputPosts, 100, 0);
+            service.dispatchConcurrentPosts(inputPosts, 100, 0, "userId");
 
             //tests that the correct number of batches were dispatched
             expect(testData.length).toBe(BATCH_COUNT);
@@ -208,7 +208,7 @@ describe('DispatcherService', () => {
 
             //out size and minscore are irrelevant, they are passed onto other functions
             //and their values are tested accordingly within those unit tests
-            service.dispatchConcurrentPosts(inputPosts, 100, 0);
+            service.dispatchConcurrentPosts(inputPosts, 100, 0, "userId");
 
             //tests that the correct number of batches were dispatched
             expect(testData.length).toBe(BATCH_COUNT);

--- a/src/modules/dispatcher/dispatcher.service.ts
+++ b/src/modules/dispatcher/dispatcher.service.ts
@@ -22,11 +22,13 @@ export class DispatcherService {
      * @param rawPool
      * @param outSize
      * @param minScore
+     * @param userId
      */
     dispatchConcurrentPosts(
         rawPool: readonly RawPost[],
         outSize: number,
         minScore: number,
+        userId: string,
     ): ConcurrentBatch[] {
         strictEqual(outSize > 0, true, 'dispatchConcurrentPosts -> outSize must be > 0');
 
@@ -83,7 +85,7 @@ export class DispatcherService {
 
             //we can then dispatch the job to the batch calculator, and push the promised calculation
             //to the job builder so that the JobRunner can pick them up and process them later
-            jobBuilder.push(this.batchCalculatorService.batchCalculate(jobBatch, minScore));
+            jobBuilder.push(this.batchCalculatorService.batchCalculate(jobBatch, minScore, userId));
         }
 
         return jobBuilder;

--- a/src/modules/t-line-calculator/t-line-calculator.service.spec.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.spec.ts
@@ -1,13 +1,13 @@
 import { AssertionError } from 'assert';
 import { Test, TestingModule } from '@nestjs/testing';
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { PostState, UserRelation } from '../../utils/types';
+import { CommunityRelation, PostState, UserRelation } from '../../utils/types';
 import { TLineCalculatorService } from './t-line-calculator.service';
 import { TLineCalculatorConfigService } from '../../configs/t-line-calculator.config/t-line-calculator.config.service';
 import {
     getPostState,
     relevanceTest,
-    getAuthorRelation,
+    getAuthorRelation, getCommunityRelation,
 } from './t-line-calculator.service.spec.utils';
 
 describe('TLineCalculatorService', () => {
@@ -35,18 +35,11 @@ describe('TLineCalculatorService', () => {
     //for different inputs to ensure that different inputs alter data in the correct direction
 
     describe('calculate relevance score', () => {
-        it('should calculate relevance as negative because the author is muted', () => {
-            const mutedUser: UserRelation = getAuthorRelation({ muted: true });
-            const score = relevanceTest(service, { autRelation: mutedUser });
-
-            expect(score).toBeLessThan(0);
-        });
-
         it('should calculate relevance higher if the author relation is follow=true (based on relations score)', () => {
             const followedUser: UserRelation = getAuthorRelation({
                 follows: true,
             });
-            const defaultFollowedUser: UserRelation = getAuthorRelation({
+            const defaultUser: UserRelation = getAuthorRelation({
                 follows: false,
             });
 
@@ -54,22 +47,50 @@ describe('TLineCalculatorService', () => {
                 autRelation: followedUser,
             });
             const baseScore = relevanceTest(service, {
-                autRelation: defaultFollowedUser,
+                autRelation: defaultUser,
             });
 
             expect(testScore).toBeGreaterThan(baseScore);
         });
 
         it('should calculate relevance higher if the community relation is follow=true (based on relations score)', () => {
+            const communityFollowedRelation: CommunityRelation = getCommunityRelation({
+                follows: true,
+            });
+            const defaultCommunity: CommunityRelation = getCommunityRelation({
+                follows: false,
+            });
+
+            const testScore = relevanceTest(service, {
+                secRelation: communityFollowedRelation,
+            });
+            const baseScore = relevanceTest(service, {
+                secRelation: defaultCommunity,
+            });
+
+            expect(testScore).toBeGreaterThan(baseScore);
 
         });
 
-        it('should calculate relevance higher for communities with higher score', () => {
+        it('should calculate relevance higher for communities with higher relevance score', () => {
+            const scoredCommunity: CommunityRelation = getCommunityRelation({ score: 20 });
+            const defaultScoredCommunity: CommunityRelation = getCommunityRelation({
+                score: 19,
+            });
+
+            const testScore = relevanceTest(service, {
+                secRelation: scoredCommunity,
+            });
+            const baseScore = relevanceTest(service, {
+                secRelation: defaultScoredCommunity,
+            });
+
+            expect(testScore).toBeGreaterThan(baseScore);
 
         });
         
 
-        it("should calculate relevance higher if autUsers' score is higher", () => {
+        it("should calculate relevance higher if autUsers' relation score is higher", () => {
             const scoredUser: UserRelation = getAuthorRelation({ score: 20 });
             const defaultScoredUser: UserRelation = getAuthorRelation({
                 score: 19,
@@ -109,7 +130,7 @@ describe('TLineCalculatorService', () => {
             expect(testScore).toBeGreaterThan(baseScore);
         });
 
-        it('should calculate relevance higher for secs with higher score', () => {
+        it('should calculate relevance higher for communities with higher score', () => {
             const testScore = relevanceTest(service, { secScore: 50 });
             const baseScore = relevanceTest(service, { secScore: 49 });
 

--- a/src/modules/t-line-calculator/t-line-calculator.service.spec.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.spec.ts
@@ -42,7 +42,7 @@ describe('TLineCalculatorService', () => {
             expect(score).toBeLessThan(0);
         });
 
-        it('should calculate relevance higher if follow=true (based on rel score)', () => {
+        it('should calculate relevance higher if the author relation is follow=true (based on relations score)', () => {
             const followedUser: UserRelation = getAuthorRelation({
                 follows: true,
             });
@@ -59,6 +59,15 @@ describe('TLineCalculatorService', () => {
 
             expect(testScore).toBeGreaterThan(baseScore);
         });
+
+        it('should calculate relevance higher if the community relation is follow=true (based on relations score)', () => {
+
+        });
+
+        it('should calculate relevance higher for communities with higher score', () => {
+
+        });
+        
 
         it("should calculate relevance higher if autUsers' score is higher", () => {
             const scoredUser: UserRelation = getAuthorRelation({ score: 20 });

--- a/src/modules/t-line-calculator/t-line-calculator.service.spec.utils.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.spec.utils.ts
@@ -1,6 +1,6 @@
 //functions to handle object defaults
 
-import { PostState, UserRelation } from '../../utils/types';
+import { CommunityRelation, PostState, UserRelation } from '../../utils/types';
 import { TLineCalculatorService } from './t-line-calculator.service';
 
 /**test utility to provide default values for the attributes not being tested
@@ -18,6 +18,24 @@ export function getAuthorRelation({
     muted?: boolean;
     score?: number;
 }): UserRelation {
+    return { follows, muted, score };
+}
+
+/**test utility to provide default values for the attributes not being tested
+ *
+ * @param follows
+ * @param muted
+ * @param score
+ */
+export function getCommunityRelation({
+    follows = false,
+    muted = false,
+    score = 10,
+}: {
+    follows?: boolean;
+    muted?: boolean;
+    score?: number;
+}): CommunityRelation {
     return { follows, muted, score };
 }
 
@@ -52,6 +70,7 @@ export function getPostState({
  * @param autScore
  * @param thrScore
  * @param autRelation
+ * @param secRelation
  * @param postState
  */
 export function relevanceTest(
@@ -62,6 +81,7 @@ export function relevanceTest(
         autScore = 10,
         thrScore = 10,
         autRelation = getAuthorRelation({}),
+        secRelation = getCommunityRelation({}),
         postState = getPostState({}),
     }: {
         secScore?: number;
@@ -69,6 +89,7 @@ export function relevanceTest(
         autScore?: number;
         thrScore?: number;
         autRelation?: UserRelation;
+        secRelation?: CommunityRelation;
         postState?: PostState;
     },
 ): number {
@@ -78,6 +99,7 @@ export function relevanceTest(
         autScore,
         thrScore,
         autRelation,
+        secRelation,
         postState,
     );
 }

--- a/src/modules/t-line-calculator/t-line-calculator.service.spec.utils.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.spec.utils.ts
@@ -26,17 +26,20 @@ export function getAuthorRelation({
  * @param seen
  * @param weight
  * @param vote
+ * @param sess
  */
 export function getPostState({
     seen = false,
     weight = 1,
     vote = 0,
+    sess = "sess",
 }: {
     seen?: boolean;
     weight?: number;
     vote?: number;
+    sess?: string;
 }): PostState {
-    return { seen, weight, vote };
+    return { seen, weight, vote, sess };
 }
 
 /**test utility to provide default values for the attributes not being tested

--- a/src/modules/t-line-calculator/t-line-calculator.service.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.ts
@@ -68,7 +68,7 @@ export class TLineCalculatorService {
      * Relational Score - a score based on the relation between the requesting user and the specified node
      * Personal Score - a score based on an individual node
      *
-     * @param secRelationalScore
+     * @param secPersonalScore
      * @param postPersonalScore
      * @param authorsPersonalScore
      * @param thrRelationalScore
@@ -85,9 +85,6 @@ export class TLineCalculatorService {
         secRelation: CommunityRelation,
         postState: PostState,
     ): number {
-        //negative scores are rejected
-        if (autRelation.muted) return -1;
-
         //followed authors get a score boost
         const authorRelationalScore = this.conditionalWeight(
             autRelation.follows,

--- a/src/modules/t-line-calculator/t-line-calculator.service.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.ts
@@ -93,13 +93,18 @@ export class TLineCalculatorService {
         );
 
         //todo sec rel score
-        const secRelationalScore = secRelation.score;
+        const secRelationalScore = this.conditionalWeight(
+            secRelation.follows,
+            secRelation.score,
+            this.C.C_FOLLOW_BOOST,
+        );
 
         //todo add sec personal score
 
         //calculate score by weighting all the values. The weights should be tweaked according to A/B testing
         const score = this.weighted(
             this.weighted(secRelationalScore, this.C.SW_SEC_REL) +
+                this.weighted(secPersonalScore, this.C.SW_SEC_PER) +
                 this.weighted(authorsPersonalScore, this.C.SW_AUTHOR_PER) +
                 this.weighted(authorRelationalScore, this.C.SW_AUTHOR_REL) +
                 this.weighted(thrRelationalScore, this.C.SW_THREAD_REL) +

--- a/src/modules/t-line-calculator/t-line-calculator.service.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { strictEqual } from 'assert';
-import { PostState, UserRelation } from '../../utils/types';
+import { CommunityRelation, PostState, UserRelation } from '../../utils/types';
 import { TLineCalculatorConfigService } from '../../configs/t-line-calculator.config/t-line-calculator.config.service';
 
 @Injectable()
@@ -73,14 +73,16 @@ export class TLineCalculatorService {
      * @param authorsPersonalScore
      * @param thrRelationalScore
      * @param autRelation
+     * @param secRelation
      * @param postState
      */
     calculateRelevanceScore(
-        secRelationalScore: number,
+        secPersonalScore: number,
         postPersonalScore: number,
         authorsPersonalScore: number,
         thrRelationalScore: number,
         autRelation: UserRelation,
+        secRelation: CommunityRelation,
         postState: PostState,
     ): number {
         //negative scores are rejected
@@ -92,6 +94,11 @@ export class TLineCalculatorService {
             autRelation.score,
             this.C.C_FOLLOW_BOOST,
         );
+
+        //todo sec rel score
+        const secRelationalScore = secRelation.score;
+
+        //todo add sec personal score
 
         //calculate score by weighting all the values. The weights should be tweaked according to A/B testing
         const score = this.weighted(

--- a/src/modules/t-line-calculator/t-line-calculator.service.ts
+++ b/src/modules/t-line-calculator/t-line-calculator.service.ts
@@ -92,14 +92,12 @@ export class TLineCalculatorService {
             this.C.C_FOLLOW_BOOST,
         );
 
-        //todo sec rel score
+        //followed communities get a follow boost
         const secRelationalScore = this.conditionalWeight(
             secRelation.follows,
             secRelation.score,
             this.C.C_FOLLOW_BOOST,
         );
-
-        //todo add sec personal score
 
         //calculate score by weighting all the values. The weights should be tweaked according to A/B testing
         const score = this.weighted(

--- a/src/utils/TLineCacheQueriesEnum.ts
+++ b/src/utils/TLineCacheQueriesEnum.ts
@@ -1,25 +1,5 @@
 export enum TLineCacheQueriesEnum {
-    GET_POOL,
-    SET_POOL,
-    POP_POOL,
-
-    GET_POOL_POST,
-    SET_POOL_POST,
-
-    GET_SEEN,
-    SET_SEEN,
-
-    GET_SEC_LIST,
-    SET_SEC_LIST,
-    POP_SEC_LIST,
-
-    GET_USER_LIST,
-    SET_USER_LIST,
-    POP_USER_LIST,
-
-    GET_SEC,
-    SET_SEC,
-
-    GET_USER,
-    SET_USER,
+    GET_SEEN_COUNT_PER_COMMUNITY,
+    GET_SESSION_ID,
+    EXISTS_IN_METADATA,
 }

--- a/src/utils/getRawPostObject.spec.util.ts
+++ b/src/utils/getRawPostObject.spec.util.ts
@@ -9,6 +9,6 @@ export default (id: number, sec?: string): RawPost => {
         thrRelationalScore: 10,
         secRelationalScore: 10,
         autRelation: { follows: false, muted: true, score: 10 },
-        postState: { weight: 10, vote: 0, seen: false },
+        postState: { weight: 10, vote: 0, seen: false, sess: "sess" },
     };
 };

--- a/src/utils/getRawPostObject.spec.util.ts
+++ b/src/utils/getRawPostObject.spec.util.ts
@@ -1,6 +1,11 @@
 import { RawPost } from './types';
 
-export default (id: number, sec?: string): RawPost => {
+export default (
+    id: number,
+    sec?: string,
+    authMuted: boolean = false,
+    commMuted: boolean = false,
+): RawPost => {
     return {
         id: `MOCK${id}`,
         sec: sec ?? `tests${id}`,
@@ -8,7 +13,8 @@ export default (id: number, sec?: string): RawPost => {
         postPersonalScore: 10,
         thrRelationalScore: 10,
         secPersonalScore: 10,
-        autRelation: { follows: false, muted: true, score: 10 },
-        postState: { weight: 10, vote: 0, seen: false, sess: "sess" },
+        autRelation: { follows: false, muted: authMuted, score: 10 },
+        secRelation: { follows: false, muted: commMuted, score: 10 },
+        postState: { weight: 10, vote: 0, seen: false, sess: 'sess' },
     };
 };

--- a/src/utils/getRawPostObject.spec.util.ts
+++ b/src/utils/getRawPostObject.spec.util.ts
@@ -7,7 +7,7 @@ export default (id: number, sec?: string): RawPost => {
         authorsPersonalScore: 10,
         postPersonalScore: 10,
         thrRelationalScore: 10,
-        secRelationalScore: 10,
+        secPersonalScore: 10,
         autRelation: { follows: false, muted: true, score: 10 },
         postState: { weight: 10, vote: 0, seen: false, sess: "sess" },
     };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,6 +6,9 @@ export type UserRelation = Readonly<{
     muted: boolean;
     score: number;
 }>;
+
+export type CommunityRelation = UserRelation;
+
 export type PostState = Readonly<{
     weight: number;
     seen: boolean;
@@ -16,10 +19,11 @@ export type PostState = Readonly<{
 export type RawPost = Readonly<{
     id: string;
     sec: string;
-    secRelationalScore: number;
+    secPersonalScore: number;
     postPersonalScore: number;
     authorsPersonalScore: number;
     thrRelationalScore: number;
+    secRelation: CommunityRelation;
     autRelation: UserRelation;
     postState: PostState;
 }>;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,6 +10,7 @@ export type PostState = Readonly<{
     weight: number;
     seen: boolean;
     vote: number;
+    sess: string;
 }>;
 
 export type RawPost = Readonly<{


### PR DESCRIPTION
updated some of the documentation for the redis storage before proceeding with the implementation. Also made some minor modifications to the stage 2 calculations that generate the output that feeds into the caching system

+ implementation for rejecting posts the were already shown in the current session or are in the pre-cache pool already

+ implementation for follow boost on communities and reject muted communities

+ implementation for sec personal score weights

+ refactored reject muted users to be handled with other rejections

next steps: implement the cache management backend to handle connections to the redis instance etc

next steps: implement the system that takes the posts from the batch calculator and orders them into the pre-caches

next steps: implement the system that moves posts from the different pre-caches to the final pool

next steps: LPOP the final pool and return postIds, seen boolean, and user vote score