### PR TITLE
init cache setup

### DIFF
--- a/src/configs/cache-expirations/expire.ts
+++ b/src/configs/cache-expirations/expire.ts
@@ -1,0 +1,1 @@
+export const SESS_ID_EXPIRE = 2.5 * 60 * 60; //2.5 hours

--- a/src/configs/cache-keys/expire.ts
+++ b/src/configs/cache-keys/expire.ts
@@ -1,0 +1,1 @@
+export function GET_SESSION_KEY(userId) {return `tline:${userId}:sessid`}

--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -8,7 +8,7 @@ import { ClearCacheModule } from './job-runner-coordination/clear-cache/clear-ca
 import { InitCacheModule } from './job-runner-coordination/init-cache/init-cache.module';
 import { LoadNextPostsModule } from './job-runner-coordination/load-next-posts/load-next-posts.module';
 import { NeoDriverModule } from './neo-driver/neo-driver.module';
-import { Stage2CacheManagementModule } from './stage2-processing/stage2-cache-management/stage2-cache-management.module';
+// import { Stage2CacheManagementModule } from './stage2-processing/stage2-cache-management/stage2-cache-management.module';
 
 @Module({
     imports: [
@@ -21,7 +21,7 @@ import { Stage2CacheManagementModule } from './stage2-processing/stage2-cache-ma
         InitCacheModule,
         LoadNextPostsModule,
         NeoDriverModule,
-        Stage2CacheManagementModule,
+        // Stage2CacheManagementModule,
     ],
 })
 export class AppModule {}

--- a/src/modules/job-runner-coordination/init-cache/init-cache.module.ts
+++ b/src/modules/job-runner-coordination/init-cache/init-cache.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { InitCacheService } from './init-cache.service';
-import { TlineCacherModule } from '../../tline-cacher/tline-cacher.module';
+import { RedisCacheDriverModule } from '../../redis-cache-driver/redis-cache-driver.module';
 
 @Module({
     providers: [InitCacheService],
     exports: [InitCacheService],
-    imports: [TlineCacherModule],
+    imports: [RedisCacheDriverModule],
 })
 export class InitCacheModule {}

--- a/src/modules/job-runner-coordination/init-cache/init-cache.service.spec.ts
+++ b/src/modules/job-runner-coordination/init-cache/init-cache.service.spec.ts
@@ -5,6 +5,7 @@ import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-dr
 import { JobTypes } from '../../../utils/JobTypes';
 import { DiscoveryModes } from '../../../utils/DiscoveryModes';
 import { SESS_ID_EXPIRE } from '../../../configs/cache-expirations/expire';
+import { GET_SESSION_KEY } from '../../../configs/cache-keys/expire';
 
 describe('InitCacheService', () => {
     let service: InitCacheService;
@@ -76,7 +77,7 @@ describe('InitCacheService', () => {
             });
 
             //check it was valid
-            expect(RedisMock.set).toBeCalledWith(`tline:${userId}:sessid`, sessId, {EX: SESS_ID_EXPIRE});
+            expect(RedisMock.set).toBeCalledWith(GET_SESSION_KEY(userId), sessId, {EX: SESS_ID_EXPIRE});
             expect(output).toBe(JobTypes.CONTINUE);
         });
     });

--- a/src/modules/job-runner-coordination/init-cache/init-cache.service.spec.ts
+++ b/src/modules/job-runner-coordination/init-cache/init-cache.service.spec.ts
@@ -1,28 +1,83 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { InitCacheService } from './init-cache.service';
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { TlineCacherService } from '../../tline-cacher/tline-cacher.service';
+import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
+import { JobTypes } from '../../../utils/JobTypes';
+import { DiscoveryModes } from '../../../utils/DiscoveryModes';
+import { SESS_ID_EXPIRE } from '../../../configs/cache-expirations/expire';
 
 describe('InitCacheService', () => {
     let service: InitCacheService;
+    let cache: RedisCacheDriverService;
+
+    const RedisMock = {
+        set: jest.fn(),
+        get: jest.fn(),
+    };
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 InitCacheService,
                 {
-                    provide: TlineCacherService,
+                    provide: RedisCacheDriverService,
                     useValue: {
-                        dispatch: jest.fn(),
+                        getClient: jest.fn(),
                     },
                 },
             ],
         }).compile();
 
         service = module.get<InitCacheService>(InitCacheService);
+        cache = module.get<RedisCacheDriverService>(RedisCacheDriverService);
+
+        // @ts-expect-error - mocked data is only mocking required functions and irrelevant ones are un mocked
+        jest.spyOn(cache, 'getClient').mockResolvedValue(RedisMock);
+    });
+
+    afterEach(() => {
+        RedisMock.set.mockReset();
+        RedisMock.get.mockReset();
     });
 
     it('should be defined', () => {
         expect(service).toBeDefined();
+    });
+
+    describe('initialize the cache tests', () => {
+        it('should abort if the cache is already initialized', async () => {
+            RedisMock.get.mockResolvedValue('dhfaasjk');
+
+            const output: JobTypes = await service.initJob({
+                jobType: JobTypes.INIT,
+                userid: '123321',
+                jobid: '000000',
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION, DiscoveryModes.FOLLOWED_USER],
+                publish: 10,
+            });
+
+            expect(output).toBe(JobTypes.ABORT);
+        });
+        it('should initialize the cache with sessid', async () => {
+            const userId = '123321';
+            const sessId = 'AAAAAA'
+
+            //set up spy
+            jest.spyOn(service, "randomSessionId").mockReturnValue(sessId);
+            RedisMock.get.mockResolvedValue(null);
+
+            //run the test
+            const output: JobTypes = await service.initJob({
+                jobType: JobTypes.INIT,
+                userid: userId,
+                jobid: '000000',
+                modes: [DiscoveryModes.FOLLOWED_SUBSECTION, DiscoveryModes.FOLLOWED_USER],
+                publish: 10,
+            });
+
+            //check it was valid
+            expect(RedisMock.set).toBeCalledWith(`tline:${userId}:sessid`, sessId, {EX: SESS_ID_EXPIRE});
+            expect(output).toBe(JobTypes.CONTINUE);
+        });
     });
 });

--- a/src/modules/job-runner-coordination/init-cache/init-cache.service.ts
+++ b/src/modules/job-runner-coordination/init-cache/init-cache.service.ts
@@ -1,13 +1,39 @@
 import { Injectable } from '@nestjs/common';
 import { InitJobListing, JobResult } from '../../../utils/types';
 import { JobTypes } from '../../../utils/JobTypes';
-import { TlineCacherService } from '../../tline-cacher/tline-cacher.service';
+import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
+import { SESS_ID_EXPIRE } from '../../../configs/cache-expirations/expire';
 
 @Injectable()
 export class InitCacheService {
-    constructor(private readonly tlineCacherService: TlineCacherService) {}
+    constructor(private readonly cacheService: RedisCacheDriverService) {}
 
+    /**initJob
+     *
+     * This job initializes the cache with a new session ID
+     *
+     * @param job
+     */
     async initJob(job: InitJobListing): Promise<JobResult> {
+        //init constants
+        const LOOKUP_KEY = `tline:${job.userid}:sessid`;
+
+        //initialize the client
+        const client = await this.cacheService.getClient();
+
+        //get the current cached value, only continue if it is not set
+        const current = await client.get(LOOKUP_KEY);
+        if (current !== null) return JobTypes.ABORT;
+
+        //set the new session ID with an expiration time
+        await client.set(LOOKUP_KEY, this.randomSessionId(), {EX: SESS_ID_EXPIRE});
         return JobTypes.CONTINUE;
+    }
+
+    //generate a random 6-digit hex string
+    randomSessionId(): string {
+        let out = '';
+        for (let i = 0; i < 6; i++) out += Math.floor(Math.random() * 16).toString(16);
+        return out;
     }
 }

--- a/src/modules/job-runner-coordination/init-cache/init-cache.service.ts
+++ b/src/modules/job-runner-coordination/init-cache/init-cache.service.ts
@@ -3,6 +3,7 @@ import { InitJobListing, JobResult } from '../../../utils/types';
 import { JobTypes } from '../../../utils/JobTypes';
 import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
 import { SESS_ID_EXPIRE } from '../../../configs/cache-expirations/expire';
+import { GET_SESSION_KEY } from '../../../configs/cache-keys/expire';
 
 @Injectable()
 export class InitCacheService {
@@ -16,7 +17,7 @@ export class InitCacheService {
      */
     async initJob(job: InitJobListing): Promise<JobResult> {
         //init constants
-        const LOOKUP_KEY = `tline:${job.userid}:sessid`;
+        const LOOKUP_KEY = GET_SESSION_KEY(job.userid);
 
         //initialize the client
         const client = await this.cacheService.getClient();

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -58,10 +58,10 @@ export interface QueryJobListing extends GenericJobListing {
     readonly jobType: JobTypes.QUERY | CASCADE;
     //modes for the query
     readonly modes: DiscoveryModes[];
-    //how large should the queried input be
-    readonly query: number;
-    //how large should the cache // output be
-    readonly cache: number;
+    //how large should the queried input be (default value is stored in cache)
+    readonly query?: number;
+    //how large should the cache // output be (default value is stored in cache)
+    readonly cache?: number;
 }
 
 export interface LoadJobListing extends GenericJobListing {


### PR DESCRIPTION
This PR sets up the service that initializes the session ID in the cache

```
Test Suites: 16 passed, 16 total
Tests:       5 skipped, 74 passed, 79 total
Snapshots:   0 total
Time:        14.409 s
Ran all test suites.
```