### PR TITLE
setup stage 1 cache management

### DIFF
--- a/src/configs/cache-keys/keys.ts
+++ b/src/configs/cache-keys/keys.ts
@@ -1,3 +1,7 @@
-export function GET_SESSION_KEY(userId:string) {return `tline:${userId}:sessid`}
+import { DiscoveryModes } from '../../utils/DiscoveryModes';
+
+export function GET_SESSION_KEY(userId:string){return `tline:${userId}:sessid`}
 export function GET_METADATA_KEY(userId:string, postId:string) {return `tline:${userId}:metadata:${postId}`}
 export function GET_PER_CATEGORY_KEY(userId:string, postCommunity:string) {return `tline:${userId}:percategory:${postCommunity}`}
+export function GET_PER_CACHE_LIMIT_KEY(userId:string, cacheId:DiscoveryModes) {return `tline:${userId}:limit:${cacheId}`}
+export function GET_PER_CACHE_SKIP_KEY(userId:string, cacheId:DiscoveryModes) {return `tline:${userId}:skip:${cacheId}`}

--- a/src/configs/pre-cache-configuration/defaults.ts
+++ b/src/configs/pre-cache-configuration/defaults.ts
@@ -1,0 +1,24 @@
+import { DiscoveryModes } from '../../utils/DiscoveryModes';
+
+export const defaults = {
+    [DiscoveryModes.FOLLOWED_USER]: {
+        skip: 0,
+        limit: 100,
+        cacheSize: 10,
+    },
+    [DiscoveryModes.RECOMMENDED_USER]: {
+        skip: 0,
+        limit: 50,
+        cacheSize: 5,
+    },
+    [DiscoveryModes.FOLLOWED_SUBSECTION]: {
+        skip: 0,
+        limit: 100,
+        cacheSize: 10,
+    },
+    [DiscoveryModes.RECOMMENDED_SUBSECTION]: {
+        skip: 0,
+        limit: 50,
+        cacheSize: 5,
+    },
+}

--- a/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.module.ts
+++ b/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { Stage1CacheManagementService } from './stage1-cache-management.service';
+import { RedisCacheDriverModule } from '../../redis-cache-driver/redis-cache-driver.module';
+
+@Module({
+    providers: [Stage1CacheManagementService],
+    exports: [Stage1CacheManagementService],
+    imports: [RedisCacheDriverModule],
+})
+export class Stage1CacheManagementModule {}

--- a/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.spec.ts
+++ b/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.spec.ts
@@ -1,0 +1,215 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Stage1CacheManagementService } from './stage1-cache-management.service';
+import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
+import { QueryJobListing } from '../../../utils/types';
+import { JobTypes } from '../../../utils/JobTypes';
+import { DiscoveryModes } from '../../../utils/DiscoveryModes';
+import { GET_PER_CACHE_LIMIT_KEY, GET_PER_CACHE_SKIP_KEY } from '../../../configs/cache-keys/keys';
+import { defaults } from '../../../configs/pre-cache-configuration/defaults';
+
+describe('Stage1CacheManagementService', () => {
+    let service: Stage1CacheManagementService;
+
+    const multiMock = {
+        get: jest.fn(),
+        set: jest.fn(),
+        exec: jest.fn(),
+    };
+
+    const clientMock = { multi: () => multiMock };
+
+    function getJobListing(modes: DiscoveryModes[], limit = undefined): QueryJobListing{
+        return {
+            userid: '123',
+            jobType: JobTypes.QUERY,
+            jobid: '321',
+            cache: 1,
+            modes: modes,
+            query: limit,
+        };
+    }
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                Stage1CacheManagementService,
+                {
+                    provide: RedisCacheDriverService,
+                    useValue: {
+                        getClient: () => clientMock,
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<Stage1CacheManagementService>(Stage1CacheManagementService);
+    });
+
+    afterEach(()=>{
+        multiMock.get.mockReset();
+        multiMock.set.mockReset();
+        multiMock.exec.mockReset();
+    })
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    describe('getting the limit and skip for a given job', () => {
+        it('should get limit and skip only if the job does not specify a limit', async () => {
+            //init data
+            const MODE: DiscoveryModes = DiscoveryModes.RECOMMENDED_USER;
+            const job: QueryJobListing = getJobListing([MODE]);
+
+            //setup spies
+            const getMock = jest.spyOn(multiMock, 'get');
+            jest.spyOn(multiMock, 'exec').mockResolvedValue([1000, 999]);
+
+            //run test
+            await service.getCacheData(job);
+
+            //validate test
+            expect(getMock).toHaveBeenCalledTimes(2);
+            expect(getMock).toHaveBeenNthCalledWith(1, GET_PER_CACHE_LIMIT_KEY(job.userid, MODE));
+            expect(getMock).toHaveBeenNthCalledWith(2, GET_PER_CACHE_SKIP_KEY(job.userid, MODE));
+        });
+
+        it('should not get the data from cache if the limit is specified in the job', async () => {
+            //init data
+            const MODE: DiscoveryModes = DiscoveryModes.RECOMMENDED_USER;
+            const job: QueryJobListing = getJobListing([MODE], 100);
+
+            //setup spies
+            const getMock = jest.spyOn(multiMock, 'get');
+            const execMock = jest.spyOn(multiMock, 'exec');
+
+            //run test
+            await service.getCacheData(job);
+
+            //validate test
+            expect(getMock).toHaveBeenCalledTimes(0);
+            expect(execMock).toHaveBeenCalledTimes(0);
+        });
+
+        it('should get the data for all specified discovery modes', async () => {
+            //init data
+            const job: QueryJobListing = getJobListing([
+                DiscoveryModes.RECOMMENDED_USER,
+                DiscoveryModes.FOLLOWED_USER,
+                DiscoveryModes.RECOMMENDED_SUBSECTION,
+                DiscoveryModes.FOLLOWED_SUBSECTION,
+            ]);
+
+            //setup spies
+            const getMock = jest.spyOn(multiMock, 'get');
+            jest.spyOn(multiMock, 'exec').mockResolvedValue([1000, 999, 888, 777]);
+
+            //run test
+            await service.getCacheData(job);
+
+            //validate test
+            expect(getMock).toHaveBeenCalledTimes(job.modes.length * 2);
+            for (let i = 0; i < job.modes.length * 2; i += 2) {
+                expect(getMock).toHaveBeenNthCalledWith(
+                    i,
+                    GET_PER_CACHE_LIMIT_KEY(job.userid, job.modes[i / 2]),
+                );
+                expect(getMock).toHaveBeenNthCalledWith(
+                    i + 1,
+                    GET_PER_CACHE_SKIP_KEY(job.userid, job.modes[i / 2]),
+                );
+            }
+        });
+    });
+
+    describe('data should be parsed and formatted', () => {
+        it('should use the limit specified in the job and a skip of 0 if the job does specify a limit', async () => {
+            //init data
+            const MODE: DiscoveryModes = DiscoveryModes.RECOMMENDED_USER;
+            const LIMIT = 55;
+            const job: QueryJobListing = getJobListing([MODE], LIMIT);
+
+            //run test
+            const output = await service.getCacheData(job);
+
+            //validate test
+            expect(output[MODE].limit).toHaveBeenCalledTimes(LIMIT);
+            expect(output[MODE].skip).toHaveBeenCalledTimes(0);
+        });
+
+        it('should format the default data for un-initialized pre-caches', async () => {
+            //init data
+            const MODE: DiscoveryModes = DiscoveryModes.RECOMMENDED_USER;
+            const job: QueryJobListing = getJobListing([MODE]);
+
+            //setup spies
+            jest.spyOn(multiMock, 'exec').mockResolvedValue([null, null]);
+
+            //run test
+            const output = await service.getCacheData(job);
+
+            //validate test
+            expect(output[MODE].limit).toHaveBeenCalledTimes(defaults[MODE].limit);
+            expect(output[MODE].skip).toHaveBeenCalledTimes(defaults[MODE].skip);
+        });
+
+        it('should format the data returned for each pre-cache', async () => {
+            //init data
+            const MODE: DiscoveryModes = DiscoveryModes.RECOMMENDED_USER;
+            const job: QueryJobListing = getJobListing([MODE]);
+            const MOCK_LIMIT = 10;
+            const MOCK_SKIP = 20;
+
+            //setup spies
+            jest.spyOn(multiMock, 'exec').mockResolvedValue([MOCK_LIMIT, MOCK_SKIP]);
+
+            //run test
+            const output = await service.getCacheData(job);
+
+            //validate test
+            expect(output[MODE].limit).toHaveBeenCalledTimes(MOCK_LIMIT);
+            expect(output[MODE].skip).toHaveBeenCalledTimes(MOCK_SKIP);
+        });
+    });
+
+    describe('setting the limit and skip if the pre-cache has not been initialized', () => {
+        async function run(MODE: DiscoveryModes){
+            //init data
+            const job: QueryJobListing = getJobListing([MODE]);
+
+            //setup spies
+            const setMock = jest.spyOn(multiMock, 'set');
+            jest.spyOn(multiMock, 'exec').mockResolvedValue([null, null]);
+
+            //run test
+            await service.getCacheData(job);
+
+            //validate test
+            expect(setMock).toHaveBeenCalledTimes(2);
+            expect(setMock).toHaveBeenNthCalledWith(
+                1,
+                GET_PER_CACHE_LIMIT_KEY(job.userid, MODE),
+                defaults[MODE].limit,
+            );
+            expect(setMock).toHaveBeenNthCalledWith(
+                2,
+                GET_PER_CACHE_SKIP_KEY(job.userid, MODE),
+                defaults[MODE].skip,
+            );
+
+        }
+
+        it('should set the skip/limit to the default value if none is found for RECOMMENDED_USER', async () => {
+            await run(DiscoveryModes.RECOMMENDED_USER);
+        });
+        it('should set the skip/limit to the default value if none is found for FOLLOWED_USER', async () => {
+            await run(DiscoveryModes.FOLLOWED_USER);
+        });
+        it('should set the skip/limit to the default value if none is found for RECOMMENDED_SUBSECTION', async () => {
+            await run(DiscoveryModes.RECOMMENDED_SUBSECTION);
+        });
+        it('should set the skip/limit to the default value if none is found for FOLLOWED_SUBSECTION', async () => {
+            await run(DiscoveryModes.FOLLOWED_SUBSECTION);
+        });
+    });
+});

--- a/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.spec.ts
+++ b/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.spec.ts
@@ -18,7 +18,7 @@ describe('Stage1CacheManagementService', () => {
 
     const clientMock = { multi: () => multiMock };
 
-    function getJobListing(modes: DiscoveryModes[], limit = undefined): QueryJobListing{
+    function getJobListing(modes: DiscoveryModes[], limit = undefined): QueryJobListing {
         return {
             userid: '123',
             jobType: JobTypes.QUERY,
@@ -45,11 +45,11 @@ describe('Stage1CacheManagementService', () => {
         service = module.get<Stage1CacheManagementService>(Stage1CacheManagementService);
     });
 
-    afterEach(()=>{
+    afterEach(() => {
         multiMock.get.mockReset();
         multiMock.set.mockReset();
         multiMock.exec.mockReset();
-    })
+    });
 
     it('should be defined', () => {
         expect(service).toBeDefined();
@@ -111,11 +111,11 @@ describe('Stage1CacheManagementService', () => {
             expect(getMock).toHaveBeenCalledTimes(job.modes.length * 2);
             for (let i = 0; i < job.modes.length * 2; i += 2) {
                 expect(getMock).toHaveBeenNthCalledWith(
-                    i,
+                    i + 1,
                     GET_PER_CACHE_LIMIT_KEY(job.userid, job.modes[i / 2]),
                 );
                 expect(getMock).toHaveBeenNthCalledWith(
-                    i + 1,
+                    i + 2,
                     GET_PER_CACHE_SKIP_KEY(job.userid, job.modes[i / 2]),
                 );
             }
@@ -133,8 +133,8 @@ describe('Stage1CacheManagementService', () => {
             const output = await service.getCacheData(job);
 
             //validate test
-            expect(output[MODE].limit).toHaveBeenCalledTimes(LIMIT);
-            expect(output[MODE].skip).toHaveBeenCalledTimes(0);
+            expect(output[MODE].limit).toBe(LIMIT);
+            expect(output[MODE].skip).toBe(0);
         });
 
         it('should format the default data for un-initialized pre-caches', async () => {
@@ -149,8 +149,8 @@ describe('Stage1CacheManagementService', () => {
             const output = await service.getCacheData(job);
 
             //validate test
-            expect(output[MODE].limit).toHaveBeenCalledTimes(defaults[MODE].limit);
-            expect(output[MODE].skip).toHaveBeenCalledTimes(defaults[MODE].skip);
+            expect(output[MODE].limit).toBe(defaults[MODE].limit);
+            expect(output[MODE].skip).toBe(defaults[MODE].skip);
         });
 
         it('should format the data returned for each pre-cache', async () => {
@@ -167,13 +167,13 @@ describe('Stage1CacheManagementService', () => {
             const output = await service.getCacheData(job);
 
             //validate test
-            expect(output[MODE].limit).toHaveBeenCalledTimes(MOCK_LIMIT);
-            expect(output[MODE].skip).toHaveBeenCalledTimes(MOCK_SKIP);
+            expect(output[MODE].limit).toBe(MOCK_LIMIT);
+            expect(output[MODE].skip).toBe(MOCK_SKIP);
         });
     });
 
     describe('setting the limit and skip if the pre-cache has not been initialized', () => {
-        async function run(MODE: DiscoveryModes){
+        async function run(MODE: DiscoveryModes) {
             //init data
             const job: QueryJobListing = getJobListing([MODE]);
 
@@ -196,7 +196,6 @@ describe('Stage1CacheManagementService', () => {
                 GET_PER_CACHE_SKIP_KEY(job.userid, MODE),
                 defaults[MODE].skip,
             );
-
         }
 
         it('should set the skip/limit to the default value if none is found for RECOMMENDED_USER', async () => {

--- a/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.ts
+++ b/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
+import { QueryJobListing } from '../../../utils/types';
+import { DiscoveryModes } from '../../../utils/DiscoveryModes';
+
+export type ParsedQueryConfiguration = {
+    [key: number]: { skip: number; limit: number };
+};
+
+@Injectable()
+export class Stage1CacheManagementService {
+    constructor(private readonly cacheService: RedisCacheDriverService) {}
+
+    /**getCacheData
+     * gets the data from the cache that is used
+     *
+     * @param job
+     */
+    async getCacheData(job: QueryJobListing): Promise<ParsedQueryConfiguration> {
+        return {};
+    }
+
+    private queryData(modes: DiscoveryModes[]) {
+        return {};
+    }
+
+    private writeData(modes: DiscoveryModes[]) {
+        return {};
+    }
+
+    private formatFromQuery(modes: DiscoveryModes[], data: unknown[]): ParsedQueryConfiguration {
+        return {};
+    }
+
+    private formatFromJob(job: QueryJobListing): ParsedQueryConfiguration {
+        return {};
+    }
+}

--- a/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.ts
+++ b/src/modules/stage1-processing/stage1-cache-management/stage1-cache-management.service.ts
@@ -2,10 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
 import { QueryJobListing } from '../../../utils/types';
 import { DiscoveryModes } from '../../../utils/DiscoveryModes';
+import { GET_PER_CACHE_LIMIT_KEY, GET_PER_CACHE_SKIP_KEY } from '../../../configs/cache-keys/keys';
+import { defaults } from '../../../configs/pre-cache-configuration/defaults';
 
 export type ParsedQueryConfiguration = {
     [key: number]: { skip: number; limit: number };
 };
+
+type UninitializedData = { mode: number; limit: number; skip: number }[]
 
 @Injectable()
 export class Stage1CacheManagementService {
@@ -17,22 +21,93 @@ export class Stage1CacheManagementService {
      * @param job
      */
     async getCacheData(job: QueryJobListing): Promise<ParsedQueryConfiguration> {
-        return {};
+        //if the query limit is specified in the job, use that
+        if (job.query !== undefined) return this.formatFromJob(job);
+
+        //query the cached values for the required pre-cache modes
+        const cachedValues = await this.queryData(job.userid, job.modes);
+
+        //format the returned data
+        return await this.formatFromQuery(job.userid, job.modes, cachedValues);
     }
 
-    private queryData(modes: DiscoveryModes[]) {
-        return {};
+    private async queryData(userId: string, modes: DiscoveryModes[]): Promise<unknown[]> {
+        //initialilze the query client
+        const client = await this.cacheService.getClient();
+        const builder = client.multi();
+
+        //get the limit and skip for each mode
+        for (let i = 0; i < modes.length; i++) {
+            const mode = modes[i];
+            builder.get(GET_PER_CACHE_LIMIT_KEY(userId, mode));
+            builder.get(GET_PER_CACHE_SKIP_KEY(userId, mode));
+        }
+
+        //run the query
+        return await builder.exec();
     }
 
-    private writeData(modes: DiscoveryModes[]) {
-        return {};
+    private async writeData(userId: string, inputData: UninitializedData) {
+        //initialilze the query client
+        const client = await this.cacheService.getClient();
+        const builder = client.multi();
+
+        //set the limit and skip for each mode
+        for (let i = 0; i < inputData.length; i++) {
+            const singleMode = inputData[i];
+            builder.set(GET_PER_CACHE_LIMIT_KEY(userId, singleMode.mode), singleMode.limit);
+            builder.set(GET_PER_CACHE_SKIP_KEY(userId, singleMode.mode), singleMode.skip);
+        }
+
+        //run the query
+        return await builder.exec();
     }
 
-    private formatFromQuery(modes: DiscoveryModes[], data: unknown[]): ParsedQueryConfiguration {
-        return {};
+    private async formatFromQuery(
+        userId: string,
+        modes: DiscoveryModes[],
+        data: unknown[],
+    ): Promise<ParsedQueryConfiguration> {
+        //init vars
+        const output: ParsedQueryConfiguration = {};
+        const unInitialized: UninitializedData = [];
+
+        //sort each pre-cache modes results into the parsed output
+        for (let i = 0; i < modes.length*2; i+=2) {
+            const mode = modes[i/2];
+
+            //if one of the values is null then we shall (re)initialize them both to the defaults
+            if (data[i] === null || data[i + 1] === null) {
+                const limit = defaults[mode].limit;
+                const skip = defaults[mode].skip;
+                output[mode] = { limit, skip };
+                //queue for update in redis
+                unInitialized.push({ mode, limit, skip });
+            } else {
+                //the data was available in the cache
+                output[mode] = {
+                    limit: data[i] as number,
+                    skip: data[i + 1] as number,
+                };
+            }
+        }
+
+        //if data must be initialized, write it to the instance
+        if(unInitialized.length !== 0) await this.writeData(userId, unInitialized);
+
+        return output;
     }
 
     private formatFromJob(job: QueryJobListing): ParsedQueryConfiguration {
-        return {};
+        //init vars
+        const output: ParsedQueryConfiguration = {};
+
+        //set the jobs configured value for each discovery mode
+        for (let i = 0; i < job.modes.length; i++) {
+            const mode = job.modes[i];
+            output[mode] = {limit: job.query, skip: 0};
+        }
+
+        return output;
     }
 }

--- a/src/modules/stage1-processing/types.ts
+++ b/src/modules/stage1-processing/types.ts
@@ -1,0 +1,3 @@
+export type ParsedQueryConfiguration = {
+    [key: number]: { skip: number; limit: number };
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -59,7 +59,7 @@ export interface QueryJobListing extends GenericJobListing {
     //modes for the query
     readonly modes: DiscoveryModes[];
     //how large should the queried input be
-    readonly query: number;
+    readonly query?: number;
     //how large should the cache // output be
     readonly cache: number;
 }


### PR DESCRIPTION
This PR sets up the cache management for neo queries (skip and limit per discovery mode)

it initializes pre-caches to have default skip/limit values

it retrieves skip/limit values for initialized pre-caches

it allows an override by supplying a limit in the job listing, this sets skip to 0