### PR TITLE
Mutex implementation

### DIFF
--- a/src/configs/cache-expirations/expire.ts
+++ b/src/configs/cache-expirations/expire.ts
@@ -1,1 +1,2 @@
 export const MUTEX_LOCK_EXPIRE = 30 // 30 seconds should be more than enough
+export const MUTEX_LOCK_FAILED_TIMEOUT_EXPIRE = 1 // 1 second

--- a/src/configs/cache-expirations/expire.ts
+++ b/src/configs/cache-expirations/expire.ts
@@ -1,0 +1,1 @@
+export const MUTEX_LOCK_EXPIRE = 30 // 30 seconds should be more than enough

--- a/src/configs/cache-keys/keys.ts
+++ b/src/configs/cache-keys/keys.ts
@@ -1,3 +1,7 @@
+import { DiscoveryModes } from '../../utils/DiscoveryModes';
+
 export function GET_SESSION_KEY(userId:string) {return `tline:${userId}:sessid`}
 export function GET_METADATA_KEY(userId:string, postId:string) {return `tline:${userId}:metadata:${postId}`}
 export function GET_PER_CATEGORY_KEY(userId:string, postCommunity:string) {return `tline:${userId}:percategory:${postCommunity}`}
+export function GET_PRE_CACHE_KEY(userId:string, cacheId:DiscoveryModes) {return `tline:${userId}:precache:${cacheId}`}
+export function GET_PRE_CACHE_LOCK_KEY(userId:string, cacheId:DiscoveryModes) {return `tline:${userId}:precachelock:${cacheId}`}

--- a/src/configs/failsafes/limits.ts
+++ b/src/configs/failsafes/limits.ts
@@ -6,3 +6,5 @@ export function failsafe(trigger: boolean, dataToLog: { [key: string]: unknown }
 
 export const FAILSAFE_BATCH_SIZE = 1000;
 export const FAILSAFE_BATCH_COUNT = 50;
+
+export const FAILSAFE_ACQUIRE_LOCK_RECURSION = 75;

--- a/src/errors/AcquireLockError.ts
+++ b/src/errors/AcquireLockError.ts
@@ -1,0 +1,14 @@
+export class AcquireLockError extends Error {
+    constructor(path: string, depth: number) {
+        super(`AcquireLockError: could not aquire lock on ${path}. DEPTH: ${depth}`);
+
+        // Set the prototype explicitly.
+        Object.setPrototypeOf(this, AcquireLockError.prototype);
+
+        this.path = path;
+        this.depth = depth;
+    }
+    errorName: string = 'AcquireLockError';
+    path: string;
+    depth: number;
+}

--- a/src/modules/endpoints/t-line/t-line.controller.ts
+++ b/src/modules/endpoints/t-line/t-line.controller.ts
@@ -1,9 +1,16 @@
 import { Controller, Get } from '@nestjs/common';
+import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
 
 @Controller('t-line')
 export class TLineController {
+    constructor(private readonly cacheClient: RedisCacheDriverService) {
+    }
 
     @Get()
     async ping() {
+        const client = await this.cacheClient.getClient();
+        const out1 = await client.set('testing123', 'value', {NX: true, EX: 10})
+        const out2 = await client.set('testing123', 'value2', {NX: true, EX: 10})
+        console.log({out1, out2});
     }
 }

--- a/src/modules/endpoints/t-line/t-line.controller.ts
+++ b/src/modules/endpoints/t-line/t-line.controller.ts
@@ -1,16 +1,9 @@
 import { Controller, Get } from '@nestjs/common';
-import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
 
 @Controller('t-line')
 export class TLineController {
-    constructor(private readonly cacheClient: RedisCacheDriverService) {
-    }
 
     @Get()
     async ping() {
-        const client = await this.cacheClient.getClient();
-        const out1 = await client.set('testing123', 'value', {NX: true, EX: 10})
-        const out2 = await client.set('testing123', 'value2', {NX: true, EX: 10})
-        console.log({out1, out2});
     }
 }

--- a/src/modules/endpoints/t-line/t-line.module.ts
+++ b/src/modules/endpoints/t-line/t-line.module.ts
@@ -1,11 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TLineService } from './t-line.service';
 import { TLineController } from './t-line.controller';
-import { RedisCacheDriverModule } from '../../redis-cache-driver/redis-cache-driver.module';
 
 @Module({
     providers: [TLineService],
     controllers: [TLineController],
-    imports: [RedisCacheDriverModule],
 })
 export class TLineModule {}

--- a/src/modules/endpoints/t-line/t-line.module.ts
+++ b/src/modules/endpoints/t-line/t-line.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TLineService } from './t-line.service';
 import { TLineController } from './t-line.controller';
+import { RedisCacheDriverModule } from '../../redis-cache-driver/redis-cache-driver.module';
 
 @Module({
     providers: [TLineService],
     controllers: [TLineController],
-    imports: [],
+    imports: [RedisCacheDriverModule],
 })
 export class TLineModule {}

--- a/src/modules/redis/aquire-mutex/aquire-mutex.module.ts
+++ b/src/modules/redis/aquire-mutex/aquire-mutex.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AquireMutexService } from './aquire-mutex.service';
+import { RedisCacheDriverModule } from '../../redis-cache-driver/redis-cache-driver.module';
+
+@Module({
+    providers: [AquireMutexService],
+    exports: [AquireMutexService],
+    imports: [RedisCacheDriverModule],
+})
+export class AquireMutexModule {}

--- a/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
+++ b/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
@@ -52,6 +52,11 @@ describe('AquireMutexService', () => {
             //setup spies
             const setSpy = jest.spyOn(redisMock, 'set');
             setSpy.mockResolvedValue('OK');
+            setSpy.mockImplementation((path: string, signature: string, params: {EX: number, NX: boolean})=>{
+                expect(path).toBe(CACHE_LOCK_PATH);
+                expect(params.EX).toBe(MUTEX_LOCK_EXPIRE);
+                expect(params.NX).toBe(true);
+            })
 
             //run test
             const output = await service.aquireLock(CACHE_LOCK_PATH, CACHE_PATH);
@@ -68,6 +73,11 @@ describe('AquireMutexService', () => {
 
             //setup spies
             const setSpy = jest.spyOn(redisMock, 'set');
+            setSpy.mockImplementation((path: string, signature: string, params: {EX: number, NX: boolean})=>{
+                expect(path).toBe(CACHE_LOCK_PATH);
+                expect(params.EX).toBe(MUTEX_LOCK_EXPIRE);
+                expect(params.NX).toBe(true);
+            })
             setSpy.mockResolvedValue('OK');
             //mocks the first reply to be null, meaning the lock is already held
             setSpy.mockResolvedValueOnce(null);

--- a/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
+++ b/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AquiredLock, AquireMutexService } from './aquire-mutex.service';
+import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
+import { GET_PRE_CACHE_KEY, GET_PRE_CACHE_LOCK_KEY } from '../../../configs/cache-keys/keys';
+import { DiscoveryModes } from '../../../utils/DiscoveryModes';
+import { MUTEX_LOCK_EXPIRE } from '../../../configs/cache-expirations/expire';
+
+describe('AquireMutexService', () => {
+    let service: AquireMutexService;
+
+    const redisMock = {
+        set: jest.fn(),
+        get: jest.fn(),
+        del: jest.fn(),
+    };
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                AquireMutexService,
+                {
+                    provide: RedisCacheDriverService,
+                    useValue: {
+                        getClient: () => redisMock,
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<AquireMutexService>(AquireMutexService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    describe('acquires lock on a path in the redis database', () => {
+        function validateOutput(lock: AquiredLock, CACHE_LOCK_PATH:string, CACHE_PATH: string){
+            expect(lock.lockPath).toBe(CACHE_LOCK_PATH);
+            expect(lock.dataPath).toBe(CACHE_PATH);
+            //check the lock timeout is set correctly, with some tolerance for processing time (500ms)
+            expect(lock.expAt).toBeGreaterThan(new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000 - 500);
+            expect(lock.expAt).toBeLessThanOrEqual(new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000);
+        }
+
+        it('should acquire a lock on an unlocked path', async () => {
+            //init data
+            const userId = '123';
+            const CACHE_PATH = GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER);
+            const CACHE_LOCK_PATH = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
+
+            //setup spies
+            const setSpy = jest.spyOn(redisMock, 'set');
+            setSpy.mockResolvedValue('OK');
+
+            //run test
+            const output = await service.aquireLock(CACHE_LOCK_PATH, CACHE_PATH);
+
+            //validate test
+            expect(setSpy).toHaveBeenCalledTimes(1);
+            validateOutput(output, CACHE_LOCK_PATH, CACHE_PATH);
+        });
+        it('should acquire a lock on an locked path after the lock has been released', async () => {
+            //init data
+            const userId = '123';
+            const CACHE_PATH = GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER);
+            const CACHE_LOCK_PATH = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
+
+            //setup spies
+            const setSpy = jest.spyOn(redisMock, 'set');
+            setSpy.mockResolvedValue('OK');
+            //mocks the first reply to be null, meaning the lock is already held
+            setSpy.mockResolvedValueOnce(null);
+
+            //run test
+            const output = await service.aquireLock(CACHE_LOCK_PATH, CACHE_PATH);
+
+            //validate test
+            expect(setSpy).toHaveBeenCalledTimes(2);
+            validateOutput(output, CACHE_LOCK_PATH, CACHE_PATH);
+        });
+    });
+
+    describe('release lock on a path in the redis database', () => {
+        it('should release a lock on a path held by the AquiredLock', async () => {
+            //init data
+            const userId = '123';
+            const signature = "123456";
+            const lockPath = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
+            const lock: AquiredLock = {
+                expAt: new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000,
+                dataPath: GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER),
+                lockPath: lockPath,
+                uniqueSignature: signature,
+            }
+
+            //setup spies
+            const getSpy = jest.spyOn(redisMock, 'get')
+            const delSpy = jest.spyOn(redisMock, 'del')
+            getSpy.mockResolvedValue(signature);
+
+            //run test
+            const output = await service.releaseLock(lock);
+
+            //validate test
+            expect(output).toBe(true);
+            expect(delSpy).toHaveBeenCalledWith(lockPath);
+            expect(getSpy).toHaveBeenCalledWith(lockPath);
+        });
+        it('should fail to release the lock if expAt is in the past', async () => {
+            //init data
+            const userId = '123';
+            const signature = "123456";
+            const lockPath = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
+            const lock: AquiredLock = {
+                expAt: new Date().getTime() - MUTEX_LOCK_EXPIRE * 1000,
+                dataPath: GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER),
+                lockPath: lockPath,
+                uniqueSignature: signature,
+            }
+
+            //setup spies
+            const getSpy = jest.spyOn(redisMock, 'get')
+            const delSpy = jest.spyOn(redisMock, 'del')
+
+            //run test
+            const output = await service.releaseLock(lock);
+
+            //validate test
+            expect(output).toBe(false);
+            expect(delSpy).not.toHaveBeenCalled();
+            expect(getSpy).not.toHaveBeenCalled();
+
+        });
+        it('should fail to release the lock on a path not held AquiredLock', async () => {
+            //init data
+            const userId = '123';
+            const signature = "123456";
+            const lockPath = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
+            const lock: AquiredLock = {
+                expAt: new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000,
+                dataPath: GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER),
+                lockPath: lockPath,
+                uniqueSignature: signature,
+            }
+
+            //setup spies
+            const getSpy = jest.spyOn(redisMock, 'get')
+            const delSpy = jest.spyOn(redisMock, 'del')
+            getSpy.mockResolvedValue(signature+"A"); //not this locks signature
+
+            //run test
+            const output = await service.releaseLock(lock);
+
+            //validate test
+            expect(output).toBe(false);
+            expect(delSpy).not.toHaveBeenCalled();
+            expect(getSpy).toHaveBeenCalledWith(lockPath);
+        });
+    });
+});

--- a/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
+++ b/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
@@ -156,7 +156,7 @@ describe('AquireMutexService', () => {
             const signature = '123456';
             const lockPath = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
             const lock: AquiredLock = {
-                expAt: new Date().getTime() - MUTEX_LOCK_EXPIRE * 1000,
+                expAt: new Date().getTime() - 1,
                 dataPath: GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER),
                 lockPath: lockPath,
                 uniqueSignature: signature,

--- a/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
+++ b/src/modules/redis/aquire-mutex/aquire-mutex.service.spec.ts
@@ -4,6 +4,8 @@ import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-dr
 import { GET_PRE_CACHE_KEY, GET_PRE_CACHE_LOCK_KEY } from '../../../configs/cache-keys/keys';
 import { DiscoveryModes } from '../../../utils/DiscoveryModes';
 import { MUTEX_LOCK_EXPIRE } from '../../../configs/cache-expirations/expire';
+import { FAILSAFE_ACQUIRE_LOCK_RECURSION } from '../../../configs/failsafes/limits';
+import { AcquireLockError } from '../../../errors/AcquireLockError';
 
 describe('AquireMutexService', () => {
     let service: AquireMutexService;
@@ -30,16 +32,41 @@ describe('AquireMutexService', () => {
         service = module.get<AquireMutexService>(AquireMutexService);
     });
 
+    afterEach(() => {
+        redisMock.del.mockReset();
+        redisMock.set.mockReset();
+        redisMock.get.mockReset();
+    });
+
     it('should be defined', () => {
         expect(service).toBeDefined();
     });
 
+    describe('failsafe test', () => {
+        it('should throw if recursion >= FAILSAFE_ACQUIRE_LOCK_RECURSION', async () => {
+            //setup spy
+            jest.spyOn(redisMock, 'set').mockResolvedValue(null);
+
+            //try and run the function at max depth
+            try {
+                await service.aquireLock('test', 'testdata', FAILSAFE_ACQUIRE_LOCK_RECURSION);
+                expect('this line').toBe('never executed due to failsafe throwing');
+            } catch (e) {
+                //ensure thrown error is correct type
+                const thrower = () => {throw e}
+                expect(thrower).toThrow(AcquireLockError);
+            }
+        });
+    });
+
     describe('acquires lock on a path in the redis database', () => {
-        function validateOutput(lock: AquiredLock, CACHE_LOCK_PATH:string, CACHE_PATH: string){
+        function validateOutput(lock: AquiredLock, CACHE_LOCK_PATH: string, CACHE_PATH: string) {
             expect(lock.lockPath).toBe(CACHE_LOCK_PATH);
             expect(lock.dataPath).toBe(CACHE_PATH);
             //check the lock timeout is set correctly, with some tolerance for processing time (500ms)
-            expect(lock.expAt).toBeGreaterThan(new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000 - 500);
+            expect(lock.expAt).toBeGreaterThan(
+                new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000 - 500,
+            );
             expect(lock.expAt).toBeLessThanOrEqual(new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000);
         }
 
@@ -51,12 +78,15 @@ describe('AquireMutexService', () => {
 
             //setup spies
             const setSpy = jest.spyOn(redisMock, 'set');
-            setSpy.mockResolvedValue('OK');
-            setSpy.mockImplementation((path: string, signature: string, params: {EX: number, NX: boolean})=>{
-                expect(path).toBe(CACHE_LOCK_PATH);
-                expect(params.EX).toBe(MUTEX_LOCK_EXPIRE);
-                expect(params.NX).toBe(true);
-            })
+            setSpy.mockImplementation(
+                (path: string, signature: string, params: { EX: number; NX: boolean }) => {
+                    expect(path).toBe(CACHE_LOCK_PATH);
+                    expect(params.EX).toBe(MUTEX_LOCK_EXPIRE);
+                    expect(params.NX).toBe(true);
+
+                    return 'OK';
+                },
+            );
 
             //run test
             const output = await service.aquireLock(CACHE_LOCK_PATH, CACHE_PATH);
@@ -73,12 +103,15 @@ describe('AquireMutexService', () => {
 
             //setup spies
             const setSpy = jest.spyOn(redisMock, 'set');
-            setSpy.mockImplementation((path: string, signature: string, params: {EX: number, NX: boolean})=>{
-                expect(path).toBe(CACHE_LOCK_PATH);
-                expect(params.EX).toBe(MUTEX_LOCK_EXPIRE);
-                expect(params.NX).toBe(true);
-            })
-            setSpy.mockResolvedValue('OK');
+            setSpy.mockImplementation(
+                (path: string, signature: string, params: { EX: number; NX: boolean }) => {
+                    expect(path).toBe(CACHE_LOCK_PATH);
+                    expect(params.EX).toBe(MUTEX_LOCK_EXPIRE);
+                    expect(params.NX).toBe(true);
+
+                    return 'OK';
+                },
+            );
             //mocks the first reply to be null, meaning the lock is already held
             setSpy.mockResolvedValueOnce(null);
 
@@ -95,18 +128,18 @@ describe('AquireMutexService', () => {
         it('should release a lock on a path held by the AquiredLock', async () => {
             //init data
             const userId = '123';
-            const signature = "123456";
+            const signature = '123456';
             const lockPath = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
             const lock: AquiredLock = {
                 expAt: new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000,
                 dataPath: GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER),
                 lockPath: lockPath,
                 uniqueSignature: signature,
-            }
+            };
 
             //setup spies
-            const getSpy = jest.spyOn(redisMock, 'get')
-            const delSpy = jest.spyOn(redisMock, 'del')
+            const getSpy = jest.spyOn(redisMock, 'get');
+            const delSpy = jest.spyOn(redisMock, 'del');
             getSpy.mockResolvedValue(signature);
 
             //run test
@@ -120,18 +153,18 @@ describe('AquireMutexService', () => {
         it('should fail to release the lock if expAt is in the past', async () => {
             //init data
             const userId = '123';
-            const signature = "123456";
+            const signature = '123456';
             const lockPath = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
             const lock: AquiredLock = {
                 expAt: new Date().getTime() - MUTEX_LOCK_EXPIRE * 1000,
                 dataPath: GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER),
                 lockPath: lockPath,
                 uniqueSignature: signature,
-            }
+            };
 
             //setup spies
-            const getSpy = jest.spyOn(redisMock, 'get')
-            const delSpy = jest.spyOn(redisMock, 'del')
+            const getSpy = jest.spyOn(redisMock, 'get');
+            const delSpy = jest.spyOn(redisMock, 'del');
 
             //run test
             const output = await service.releaseLock(lock);
@@ -140,24 +173,23 @@ describe('AquireMutexService', () => {
             expect(output).toBe(false);
             expect(delSpy).not.toHaveBeenCalled();
             expect(getSpy).not.toHaveBeenCalled();
-
         });
         it('should fail to release the lock on a path not held AquiredLock', async () => {
             //init data
             const userId = '123';
-            const signature = "123456";
+            const signature = '123456';
             const lockPath = GET_PRE_CACHE_LOCK_KEY(userId, DiscoveryModes.FOLLOWED_USER);
             const lock: AquiredLock = {
                 expAt: new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000,
                 dataPath: GET_PRE_CACHE_KEY(userId, DiscoveryModes.FOLLOWED_USER),
                 lockPath: lockPath,
                 uniqueSignature: signature,
-            }
+            };
 
             //setup spies
-            const getSpy = jest.spyOn(redisMock, 'get')
-            const delSpy = jest.spyOn(redisMock, 'del')
-            getSpy.mockResolvedValue(signature+"A"); //not this locks signature
+            const getSpy = jest.spyOn(redisMock, 'get');
+            const delSpy = jest.spyOn(redisMock, 'del');
+            getSpy.mockResolvedValue(signature + 'A'); //not this locks signature
 
             //run test
             const output = await service.releaseLock(lock);

--- a/src/modules/redis/aquire-mutex/aquire-mutex.service.ts
+++ b/src/modules/redis/aquire-mutex/aquire-mutex.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
+
+export type AquiredLock = {
+    uniqueSignature: string,
+    lockPath: string,
+    dataPath: string,
+    expAt: number,
+}
+
+@Injectable()
+export class AquireMutexService {
+    constructor(private readonly cacheClient: RedisCacheDriverService) {}
+
+    async aquireLock(lockPath: string, dataPath: string): Promise<AquiredLock> {
+        return {
+            dataPath: dataPath,
+            lockPath: lockPath,
+            uniqueSignature: "",
+            expAt: new Date().getTime(),
+        }
+    }
+
+    async releaseLock(lock: AquiredLock): Promise<boolean> {
+        return false
+    }
+
+    private genUniqueSignature() {
+        let output = '';
+        for (let i = 0; i < 6; i++) {
+            output += (Math.floor(Math.random() * 16)).toString(16);
+        }
+        return output;
+    }
+}

--- a/src/modules/redis/aquire-mutex/aquire-mutex.service.ts
+++ b/src/modules/redis/aquire-mutex/aquire-mutex.service.ts
@@ -1,34 +1,94 @@
 import { Injectable } from '@nestjs/common';
 import { RedisCacheDriverService } from '../../redis-cache-driver/redis-cache-driver.service';
+import {
+    MUTEX_LOCK_EXPIRE,
+    MUTEX_LOCK_FAILED_TIMEOUT_EXPIRE,
+} from '../../../configs/cache-expirations/expire';
+import { FAILSAFE_ACQUIRE_LOCK_RECURSION } from '../../../configs/failsafes/limits';
+import { AcquireLockError } from '../../../errors/AcquireLockError';
+import { InvalidDataError } from '../../../errors/InvalidDataError';
 
 export type AquiredLock = {
-    uniqueSignature: string,
-    lockPath: string,
-    dataPath: string,
-    expAt: number,
-}
+    uniqueSignature: string;
+    lockPath: string;
+    dataPath: string;
+    expAt: number;
+};
 
 @Injectable()
 export class AquireMutexService {
     constructor(private readonly cacheClient: RedisCacheDriverService) {}
 
-    async aquireLock(lockPath: string, dataPath: string): Promise<AquiredLock> {
-        return {
-            dataPath: dataPath,
-            lockPath: lockPath,
-            uniqueSignature: "",
-            expAt: new Date().getTime(),
+    async aquireLock(lockPath: string, dataPath: string, depth = 0): Promise<AquiredLock> {
+        //initialize the client
+        const client = await this.cacheClient.getClient();
+
+        //init the data
+        const signature = this.genUniqueSignature();
+        const expAt = new Date().getTime() + MUTEX_LOCK_EXPIRE * 1000;
+
+        //attempt to get the lock
+        const status = await client.set(lockPath, signature, {
+            EX: MUTEX_LOCK_EXPIRE,
+            NX: true,
+        });
+
+        //redis returns null when a value is set and configured to only set if it does not exist
+        if (status === null) {
+            //failsafe to stop infinite recursion
+            if (depth >= FAILSAFE_ACQUIRE_LOCK_RECURSION)
+                throw new AcquireLockError(lockPath, depth);
+
+            return new Promise((resolve, reject) => {
+                //jitter from (-1/2 * timeout) to (+1/2 * timeout) to de-sync attempts
+                const timeoutMs = MUTEX_LOCK_FAILED_TIMEOUT_EXPIRE * 1000;
+                const jitterMs = Math.floor(Math.random() * timeoutMs) - timeoutMs / 2;
+                const totalTimeout = timeoutMs + jitterMs;
+
+                //retry
+                setTimeout(async () => {
+                    try{
+                        resolve(await this.aquireLock(lockPath, dataPath, depth + 1));
+                    }catch (e) {
+                        reject(e)
+                    }
+                }, totalTimeout);
+            });
         }
+        //redis returns status "OK" if setNX was successful
+        if (status === 'OK') {
+            return {
+                dataPath: dataPath,
+                lockPath: lockPath,
+                uniqueSignature: signature,
+                expAt: expAt,
+            };
+        }
+
+        //throw if something unexpected happened
+        throw new InvalidDataError('status', status);
     }
 
     async releaseLock(lock: AquiredLock): Promise<boolean> {
-        return false
+        //if the lock has expired, return false
+        if (lock.expAt < new Date().getTime()) return false;
+
+        //initialize the client
+        const client = await this.cacheClient.getClient();
+
+        //check the current lock held is the lock passed to this function
+        const lockedSignature = await client.get(lock.lockPath);
+        if (lockedSignature !== lock.uniqueSignature) return false;
+
+        //release the lock
+        await client.del(lock.lockPath);
+        return true;
     }
 
     private genUniqueSignature() {
         let output = '';
         for (let i = 0; i < 6; i++) {
-            output += (Math.floor(Math.random() * 16)).toString(16);
+            output += Math.floor(Math.random() * 16).toString(16);
         }
         return output;
     }


### PR DESCRIPTION
This PR implements mutex locks to paths in the redis instance.

Locks can be aquired by calling `aquireLock` and can be released with `releaseLock`

Locks expire after a configured timeout (currently 30 seconds) as recommended by redis docs